### PR TITLE
Fix event widths for non-overlapping timed events

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1747,29 +1747,57 @@ class SkylightCalendarCard extends HTMLElement {
       return (b.endMinutes - b.startMinutes) - (a.endMinutes - a.startMinutes);
     });
     
-    // Detect overlapping events and assign columns
-    const columns = [];
+    const overlaps = (first, second) =>
+      first.startMinutes < second.endMinutes && first.endMinutes > second.startMinutes;
+
+    const clusters = [];
     eventBlocks.forEach(block => {
-      // Find a column where this event doesn't overlap
-      let placed = false;
-      for (let col of columns) {
-        const overlaps = col.some(other => 
-          block.startMinutes < other.endMinutes && block.endMinutes > other.startMinutes
-        );
-        if (!overlaps) {
-          col.push(block);
-          block.column = columns.indexOf(col);
-          placed = true;
-          break;
+      const matchingClusters = [];
+      clusters.forEach((cluster, index) => {
+        if (cluster.some(other => overlaps(block, other))) {
+          matchingClusters.push(index);
         }
+      });
+
+      if (matchingClusters.length === 0) {
+        clusters.push([block]);
+        return;
       }
-      if (!placed) {
-        columns.push([block]);
-        block.column = columns.length - 1;
-      }
+
+      const targetIndex = matchingClusters.shift();
+      clusters[targetIndex].push(block);
+
+      matchingClusters.reverse().forEach(index => {
+        clusters[targetIndex].push(...clusters[index]);
+        clusters.splice(index, 1);
+      });
     });
-    
-    const totalColumns = columns.length;
+
+    clusters.forEach(cluster => {
+      const columns = [];
+      cluster.forEach(block => {
+        let placed = false;
+        for (const col of columns) {
+          const hasOverlap = col.some(other => overlaps(block, other));
+          if (!hasOverlap) {
+            col.push(block);
+            block.column = columns.indexOf(col);
+            placed = true;
+            break;
+          }
+        }
+
+        if (!placed) {
+          columns.push([block]);
+          block.column = columns.length - 1;
+        }
+      });
+
+      const clusterColumns = columns.length;
+      cluster.forEach(block => {
+        block.clusterColumns = clusterColumns;
+      });
+    });
     
     // Render timed events
     return eventBlocks.map(block => {
@@ -1779,9 +1807,10 @@ class SkylightCalendarCard extends HTMLElement {
       const top = (startHourFloat - startHour) * hourHeight;
       const height = duration * hourHeight;
       
+      const clusterColumns = block.clusterColumns || 1;
       // Calculate width and position for concurrent events
-      const width = totalColumns > 1 ? `calc((100% - 16px) / ${totalColumns})` : 'calc(100% - 16px)';
-      const left = totalColumns > 1 ? `calc(8px + ((100% - 16px) / ${totalColumns}) * ${column})` : '8px';
+      const width = clusterColumns > 1 ? `calc((100% - 16px) / ${clusterColumns})` : 'calc(100% - 16px)';
+      const left = clusterColumns > 1 ? `calc(8px + ((100% - 16px) / ${clusterColumns}) * ${column})` : '8px';
       
       const bgColor = this.lightenColor(event.color, 0.85);
       


### PR DESCRIPTION
### Motivation
- Events in the Schedule (week-standard) view that do not overlap were being shrunk because width/column calculation used a global column count, causing unrelated overlapping groups to reduce width for all events on the same day.
- The intent is to render non-overlapping events at full width while still splitting width among truly concurrent events.

### Description
- Replace the single global column assignment with an overlap clustering algorithm that groups events into connected overlap clusters using an `overlaps` predicate.
- Within each cluster, assign columns and record `clusterColumns` so only events in the same overlapping cluster share width calculations. 
- Use `block.clusterColumns` to compute `width` and `left` for each rendered timed event so isolated events render `calc(100% - 16px)` and clustered events split the available width.
- Changes implemented in `skylight-calendar-card.js` around the timed event overlap detection and rendering logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698960306f548331bd226eff231e8512)