### PR TITLE
Improve event editing reliability across calendar integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,9 @@ Click on any event to view its details, then click the **"Edit"** button to modi
 - Move event to a different calendar
 
 **How It Works:**
-- If the calendar supports the UPDATE service, changes are applied directly
-- Otherwise, the event is automatically deleted and recreated with new details
+- If `calendar.update_event` is available, changes are applied directly
+- If update is unavailable or fails, the card automatically falls back to **create first, then delete**
+- The fallback is automatic and avoids noisy "update service not found" pop-ups when edit succeeds via create+delete
 - All editing is seamless - you don't need to know which method is used!
 
 **Moving Events Between Calendars:**
@@ -256,20 +257,19 @@ readonly_calendars:
 ### Calendar Integration Compatibility
 
 **Full Support (Create, Edit, Delete):**
-- ✅ **Local Calendar** - Full support with delete+create fallback for edits
+- ✅ **Local Calendar** - Full support with create+delete fallback for edits when direct update is unavailable
 - ⚠️ **CalDAV** - Support varies by server (Nextcloud, iCloud, etc.)
 - ⚠️ **Office 365** - Create works; edit/delete support varies
 
-**Partial Support (Create, Delete only):**
-- ⚠️ **Google Calendar** - **Create and Delete work!** (Delete uses WebSocket API)
-  - **Why no edit?** Home Assistant doesn't expose a WebSocket update API for Google Calendar
-  - **Workaround for editing:** Use the Google Calendar app or website
-  - Events created through this card can be deleted from Home Assistant
-  - This is a limitation of Home Assistant's Google Calendar integration, not this card
+**Fallback-Based Edit Support (No direct update API):**
+- ⚠️ **Google Calendar** - Edit works through create+delete fallback when UID/delete operations are available
+  - Direct `calendar.update_event` may not exist for this integration
+  - The card handles this by creating the replacement event first, then deleting the original
+  - Delete uses Home Assistant's calendar delete capabilities (WebSocket first, service fallback)
 
-**How Editing Works (Non-Google Calendars):**
-1. **UPDATE Service Available** - Event is modified directly (fastest, preserves UID)
-2. **Fallback Method** - Event is deleted and recreated (works on calendars with delete+create)
+**How Editing Works (All Calendars):**
+1. **Direct Update Path** - If `calendar.update_event` exists, event is modified directly (fastest, preserves UID)
+2. **Fallback Path** - Create the new event first, then delete the old event (prevents data loss if create fails)
 
 **How Deletion Works:**
 1. **WebSocket API** (Primary) - Works for Google Calendar and most modern integrations

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -2910,6 +2910,22 @@ class SkylightCalendarCard extends HTMLElement {
         await this.updateEvents();
       } catch (error) {
         console.error('Failed to update event:', error);
+
+        // Safety net: if edit was blocked by capability detection, still try create+delete.
+        // Some integrations misreport update/delete support even though create+delete works.
+        if (error.message === this.t('calendarNoModifyError')) {
+          try {
+            await this.createEvent(calendarId, eventData);
+            await this.deleteEvent(event.entityId, event.uid, event.recurrence_id);
+            modal.classList.remove('show');
+            this._lastFetch = null;
+            await this.updateEvents();
+            return;
+          } catch (fallbackError) {
+            console.error('Safety-net create+delete fallback failed:', fallbackError);
+          }
+        }
+
         this.showFormError(errorDiv, error.message || this.t('failedUpdateEvent'));
         submitBtn.disabled = false;
         submitBtn.textContent = this.t('saveChanges');
@@ -2932,17 +2948,13 @@ class SkylightCalendarCard extends HTMLElement {
     // Check if we're moving to a different calendar
     const movingCalendar = newCalendarId !== originalEvent.entityId;
     
-    // Google Calendar and other calendars without UID support can't be edited
-    if (capabilities.isGoogleCalendar) {
-      throw new Error(this.t('googleCalendarEditError'));
-    }
-    
     if (!originalEvent.uid) {
       throw new Error(this.t('missingUidError'));
     }
     
-    // If calendar supports UPDATE and we're not moving calendars, use update service
-    if (capabilities.canUpdate && !movingCalendar) {
+    // If calendar supports UPDATE, we're not moving calendars, and service exists, use update service
+    const hasUpdateService = !!this._hass.services?.calendar?.update_event;
+    if (capabilities.canUpdate && !movingCalendar && hasUpdateService) {
       try {
         const serviceData = {
           entity_id: originalEvent.entityId,
@@ -2977,25 +2989,26 @@ class SkylightCalendarCard extends HTMLElement {
         await this._hass.callService('calendar', 'update_event', serviceData);
         return;
       } catch (error) {
-        console.error('Update service failed, trying delete+create fallback:', error.message);
-        // Fall through to delete+create pattern
+        console.error('Update service failed, trying create+delete fallback:', error.message);
+        // Fall through to create+delete pattern
       }
+    } else if (capabilities.canUpdate && !movingCalendar && !hasUpdateService) {
+      // Some integrations advertise update support but the service is not registered.
+      // Skip update call to avoid misleading "Action calendar.update_event not found" pop-ups.
+      console.debug('calendar.update_event service unavailable, using create+delete fallback');
     }
     
-    // Fallback: Delete old event and create new one
-    // This works even when moving between calendars or when UPDATE is not supported
-    if (!capabilities.canDelete) {
-      throw new Error(this.t('calendarNoModifyError'));
-    }
-    
+    // Fallback: Create new event and then delete old one
+    // This prevents data loss when create fails on calendars without UPDATE support
+
     try {
-      // Delete from original calendar
-      await this.deleteEvent(originalEvent.entityId, originalEvent.uid, originalEvent.recurrence_id);
-      
-      // Create in new calendar (might be same or different)
+      // Create in destination calendar first (might be same or different)
       await this.createEvent(newCalendarId, eventData);
+
+      // Delete from original calendar only after successful create
+      await this.deleteEvent(originalEvent.entityId, originalEvent.uid, originalEvent.recurrence_id);
     } catch (error) {
-      console.error('Delete+Create fallback failed:', error);
+      console.error('Create+Delete fallback failed:', error);
       throw new Error(error.message || this.t('updateEventServiceError'));
     }
   }
@@ -3272,9 +3285,8 @@ class SkylightCalendarCard extends HTMLElement {
                      !capabilities.isReadonly && 
                      hasUID;
     
-    // WebSocket delete works for Google Calendar!
-    // Only editing doesn't work (no WebSocket update API)
-    const canEdit = canModify && !capabilities.isGoogleCalendar;
+    // WebSocket delete works for Google Calendar and other integrations
+    const canEdit = canModify;
     const canDelete = canModify; // WebSocket delete works for all calendars including Google
     
     content.innerHTML = `


### PR DESCRIPTION
# Improve event editing reliability across calendar integrations
This PR improves event update behavior for calendars with inconsistent or partial modification support.

## Key changes:
- Uses calendar.update_event only when the service is actually registered.
- Replaces delete-then-create with a safer create-then-delete fallback to prevent data loss.
- Adds a safety-net fallback when edits are blocked by misreported capabilities.
- Removes Google Calendar–specific edit restrictions; editing now relies on actual capabilities and UID presence.
- Improves error handling and logging around update failures.

These changes make editing events more reliable across Google Calendar and other HA calendar integrations that misreport update/delete support.