### PR TITLE
Fix rolling_weeks forward navigation in month view

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1640,13 +1640,13 @@ class SkylightCalendarCard extends HTMLElement {
     if (this._viewMode === 'month') {
       // If rolling_weeks mode is active, show date range
       if (this._config.rolling_weeks !== null) {
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
+        const anchorDate = new Date(this._currentDate);
+        anchorDate.setHours(0, 0, 0, 0);
         
-        const currentDay = today.getDay();
+        const currentDay = anchorDate.getDay();
         const diff = (currentDay - this._config.firstDayOfWeek + 7) % 7;
-        const weekStart = new Date(today);
-        weekStart.setDate(today.getDate() - diff);
+        const weekStart = new Date(anchorDate);
+        weekStart.setDate(anchorDate.getDate() - diff);
         
         const totalWeeks = this._config.rolling_weeks + 1;
         const weekEnd = new Date(weekStart);
@@ -2126,14 +2126,14 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderRollingWeeks() {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+    const anchorDate = new Date(this._currentDate);
+    anchorDate.setHours(0, 0, 0, 0);
     
     // Find the start of the current week based on firstDayOfWeek
-    const currentDay = today.getDay();
+    const currentDay = anchorDate.getDay();
     const diff = (currentDay - this._config.firstDayOfWeek + 7) % 7;
-    const weekStart = new Date(today);
-    weekStart.setDate(today.getDate() - diff);
+    const weekStart = new Date(anchorDate);
+    weekStart.setDate(anchorDate.getDate() - diff);
     
     // Calculate total days to show: (rolling_weeks + 1) * 7 days
     const totalWeeks = this._config.rolling_weeks + 1;


### PR DESCRIPTION
### Motivation
- The month view in `rolling_weeks` mode was always anchored to the real current date (`new Date()`), so clicking the forward arrow didn't move the displayed rolling window even though `_currentDate` was being updated.

### Description
- Anchor rolling range calculation and label generation to the card's `this._currentDate` by creating an `anchorDate = new Date(this._currentDate)` instead of using `new Date()` in `getPeriodLabel()`.
- Anchor rolling grid rendering to `this._currentDate` by using `anchorDate` when computing the week start in `renderRollingWeeks()` so the visible days advance/retreat with navigation.
- No change to the navigation handlers themselves; this makes `prev/next` behave consistently because rendering and labels now use the same `_currentDate` reference.

### Testing
- Ran `node --check skylight-calendar-card.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bad0b483883319e6587462acde4b1)