### PR TITLE
Fix pop-ups closing immediately by avoiding unnecessary re-render

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -519,7 +519,6 @@ class SkylightCalendarCard extends HTMLElement {
     // Gate fetches on the actually visible range. If the user can already see
     // all required dates from loaded data, avoid any network call.
     if (this.isDateRangeCoveredByLoadedEvents(visibleStartDate, visibleEndDate)) {
-      this.render();
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Frequent Home Assistant updates caused the card to rebuild its DOM even when visible event data was already loaded, which rebuilt modal elements and made event inspect/edit/create pop-ups close immediately; the redundant `this.render()` in `ensureEventsForCurrentRange()` was the trigger.

### Description
- Remove the unnecessary `this.render()` call from the early-return branch in `ensureEventsForCurrentRange()` so the card doesn't re-render when the visible date range is already covered by loaded events, preserving open modal state.

### Testing
- Ran a syntax check with `node --check skylight-calendar-card.js`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c148edfec8331b0c962bbfda4bead)