### PR TITLE
Restore navigation responsiveness without reintroducing modal auto-close

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -507,7 +507,7 @@ class SkylightCalendarCard extends HTMLElement {
            targetEndDate <= this._loadedEventRange.endDate;
   }
 
-  async ensureEventsForCurrentRange({ force = false } = {}) {
+  async ensureEventsForCurrentRange({ force = false, renderIfCovered = false } = {}) {
     const shouldRefreshForAge = !this._lastFetch || (Date.now() - this._lastFetch > 60000);
     const { startDate: visibleStartDate, endDate: visibleEndDate } = this.getVisibleDateRange();
 
@@ -519,6 +519,9 @@ class SkylightCalendarCard extends HTMLElement {
     // Gate fetches on the actually visible range. If the user can already see
     // all required dates from loaded data, avoid any network call.
     if (this.isDateRangeCoveredByLoadedEvents(visibleStartDate, visibleEndDate)) {
+      if (renderIfCovered) {
+        this.render();
+      }
       return;
     }
 
@@ -2436,7 +2439,7 @@ class SkylightCalendarCard extends HTMLElement {
         this._viewMode = button.getAttribute('data-view');
         this._config.view_mode = this._viewMode;
         this.setWeekStart();
-        this.ensureEventsForCurrentRange();
+        this.ensureEventsForCurrentRange({ renderIfCovered: true });
       });
     });
     
@@ -2478,7 +2481,7 @@ class SkylightCalendarCard extends HTMLElement {
           this.setWeekStart();
         }
       }
-      this.ensureEventsForCurrentRange();
+      this.ensureEventsForCurrentRange({ renderIfCovered: true });
     });
     
     nextButton?.addEventListener('click', () => {
@@ -2501,7 +2504,7 @@ class SkylightCalendarCard extends HTMLElement {
           this.setWeekStart();
         }
       }
-      this.ensureEventsForCurrentRange();
+      this.ensureEventsForCurrentRange({ renderIfCovered: true });
     });
     
     todayButton?.addEventListener('click', () => {
@@ -2509,7 +2512,7 @@ class SkylightCalendarCard extends HTMLElement {
       if (this._config.rolling_days === null) {
         this.setWeekStart();
       }
-      this.ensureEventsForCurrentRange();
+      this.ensureEventsForCurrentRange({ renderIfCovered: true });
     });
     
     // Event click handlers for all view modes


### PR DESCRIPTION
### Motivation
- A previous change prevented redundant re-renders to stop modals from auto-closing, but that also caused user navigation controls (prev/next arrows, Today, view switches) to stop updating the UI when the visible range was already cached.
- The intent is to allow user-driven navigation to force a UI repaint while preserving the background-update behavior that fixed the modal auto-close bug.

### Description
- Added a `renderIfCovered` option to `ensureEventsForCurrentRange` so callers can request a UI `render()` when the visible date range is already covered without forcing a network fetch (signature: `ensureEventsForCurrentRange({ force = false, renderIfCovered = false } = {})`).
- When the date range is covered and `renderIfCovered` is true, the function now calls `this.render()` before returning.
- Updated user-driven actions in `attachEventListeners` (view mode buttons, prev/next navigation buttons, and the Today button) to call `ensureEventsForCurrentRange({ renderIfCovered: true })` so these controls always repaint immediately.
- Kept Home Assistant-driven refresh calls and the fetch/age gating logic unchanged so background hass updates still avoid unnecessary re-renders (preserving the modal auto-close fix).

### Testing
- Ran `node --check skylight-calendar-card.js` which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c1e69bf848331b98b224a8519285f)