### PR TITLE
Schedule/week-standard layout scroll fix

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1183,6 +1183,7 @@ class SkylightCalendarCard extends HTMLElement {
       
       .week-standard-container {
         display: flex;
+        align-items: flex-start;
         background: #f9fafb;
         overflow-x: auto;
         padding: 16px;


### PR DESCRIPTION
## Summary
Fixed the schedule/week-standard layout so day columns no longer stretch to the scroll container height by adding align-items: flex-start to .week-standard-container. This prevents lower timed events from being clipped off when the container is vertically scrollable (e.g., compact-height scenarios).