### PR TITLE
Improve compact height behavior for month view

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ rolling_weeks: 3  # Show current + 3 more weeks (28 days)
 | `week_start_hour` | integer | `8` | Start hour for week-standard view (0-23) |
 | `week_end_hour` | integer | `21` | End hour for week-standard view (0-23) |
 | `height_scale` | float | `1.0` | Height scaling factor (0.5-2.0, affects schedule view) |
-| `compact_height` | boolean | `false` | Fit calendar to screen height with scroll |
+| `compact_height` | boolean | `false` | Fit monthly calendar and schedule views to available screen height without scrolling |
 | `compact_header` | boolean | `false` | Single-row header with inline badges |
 | `hide_event_calendar_bubble` | boolean | `false` | Hide the calendar initial bubble shown inside events |
 | `hide_times_for_calendars` | list | `[]` | Calendar entities whose start/end times should be hidden in schedule view |

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -356,8 +356,9 @@ class SkylightCalendarCard extends HTMLElement {
     this._isDarkMode = false;
     this._weekStandardFixedOffsetHeight = null;
     this._weekStandardContainerTopInViewport = null;
+    this._monthContainerTopInViewport = null;
     this._handleViewportResize = () => {
-      if (this._config.compact_height && this._viewMode === 'week-standard') {
+      if (this._config.compact_height && (this._viewMode === 'week-standard' || this._viewMode === 'month')) {
         this.render();
       }
     };
@@ -743,12 +744,12 @@ class SkylightCalendarCard extends HTMLElement {
     window.visualViewport?.removeEventListener('resize', this._handleViewportResize);
   }
 
-  getCompactMaxHeight() {
+  getCompactMaxHeight(containerTopInViewport = null) {
     if (!this._config.compact_height) return null;
 
     const viewportHeight = window.visualViewport?.height || window.innerHeight;
     const containerTop = Math.max(
-      this._weekStandardContainerTopInViewport ?? this.getBoundingClientRect().top,
+      containerTopInViewport ?? this.getBoundingClientRect().top,
       0
     );
     const bottomSpacing = 24;
@@ -796,6 +797,24 @@ class SkylightCalendarCard extends HTMLElement {
       this.render();
     }
   }
+
+
+  updateMonthContainerTopInViewportFromDom() {
+    if (this._viewMode !== 'month' || !this._config.compact_height || !this.shadowRoot) return;
+
+    const container = this.shadowRoot.querySelector('.calendar-grid');
+    if (!container) return;
+
+    const measuredContainerTop = Math.max(container.getBoundingClientRect().top, 0);
+    if (!Number.isFinite(measuredContainerTop)) return;
+
+    const containerTopChanged = this._monthContainerTopInViewport === null || Math.abs(this._monthContainerTopInViewport - measuredContainerTop) > 1;
+    if (containerTopChanged) {
+      this._monthContainerTopInViewport = measuredContainerTop;
+      this.render();
+    }
+  }
+
 
   getLanguage() {
     return resolveLanguage(this._config.language || this._hass?.language || this._hass?.locale?.language);
@@ -1086,6 +1105,15 @@ class SkylightCalendarCard extends HTMLElement {
         gap: 1px;
         background: #e5e7eb;
         border-top: 1px solid #e5e7eb;
+      }
+
+
+      .calendar-grid.compact-month {
+        align-items: stretch;
+      }
+
+      .calendar-grid.compact-month .day-cell {
+        min-height: 0;
       }
       
       .day-header {
@@ -2214,6 +2242,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     this.attachEventListeners();
     this.updateWeekStandardFixedOffsetHeightFromDom();
+    this.updateMonthContainerTopInViewportFromDom();
   }
 
   renderStandardHeader() {
@@ -2348,9 +2377,17 @@ class SkylightCalendarCard extends HTMLElement {
 
   renderCalendarView() {
     if (this._viewMode === 'month') {
+      const isCompactMonth = this._config.compact_height;
+      const compactMaxHeight = isCompactMonth ? this.getCompactMaxHeight(this._monthContainerTopInViewport) : null;
+      const monthWeekRows = this.getMonthWeekRowCount();
+      const monthStyle = compactMaxHeight
+        ? `height: ${compactMaxHeight}px; overflow-y: auto; grid-template-rows: auto repeat(${monthWeekRows}, minmax(0, 1fr));`
+        : '';
+      const monthClass = isCompactMonth ? 'calendar-grid compact-month' : 'calendar-grid';
+
       return `
         ${!this._config.compact_header ? this.renderCalendarBadges() : ''}
-        <div class="calendar-grid">
+        <div class="${monthClass}" style="${monthStyle}">
           ${this.renderDayHeaders()}
           ${this.renderDays()}
         </div>
@@ -2450,7 +2487,7 @@ class SkylightCalendarCard extends HTMLElement {
       ? 16 + (maxAllDayEvents * 24) + ((maxAllDayEvents - 1) * 4) + 2
       : 0;
 
-    const compactMaxHeight = this.getCompactMaxHeight();
+    const compactMaxHeight = this.getCompactMaxHeight(this._weekStandardContainerTopInViewport);
     const fallbackOffsetHeight = 127 + allDayHeight;
     const staticOffsetHeight = this._weekStandardFixedOffsetHeight || fallbackOffsetHeight;
     const availableSlotHeight = compactMaxHeight ? compactMaxHeight - staticOffsetHeight : null;
@@ -2737,6 +2774,19 @@ class SkylightCalendarCard extends HTMLElement {
     return `${hour - 12} PM`;
   }
 
+  getMonthWeekRowCount() {
+    if (this._config.rolling_weeks !== null && this._viewMode === 'month') {
+      return this._config.rolling_weeks + 1;
+    }
+
+    const year = this._currentDate.getFullYear();
+    const month = this._currentDate.getMonth();
+    const firstDay = new Date(year, month, 1).getDay();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const startDay = (firstDay - this._config.firstDayOfWeek + 7) % 7;
+    return Math.ceil((startDay + daysInMonth) / 7);
+  }
+
   renderDays() {
     const year = this._currentDate.getFullYear();
     const month = this._currentDate.getMonth();
@@ -2814,6 +2864,39 @@ class SkylightCalendarCard extends HTMLElement {
     return html;
   }
 
+  getMaxVisibleEventsForMonthDay() {
+    const defaultMaxVisible = 3;
+
+    if (this._viewMode !== 'month' || !this._config.compact_height) {
+      return defaultMaxVisible;
+    }
+
+    const compactMaxHeight = this.getCompactMaxHeight(this._monthContainerTopInViewport);
+    if (!compactMaxHeight) {
+      return defaultMaxVisible;
+    }
+
+    const weekRows = this.getMonthWeekRowCount();
+    if (!weekRows || weekRows < 1) {
+      return defaultMaxVisible;
+    }
+
+    const gridGap = 1;
+    const dayHeaderRowHeight = 41;
+    const verticalPadding = 16;
+    const dayNumberHeight = 32;
+    const eventRowHeight = 22;
+
+    const contentHeight = compactMaxHeight - dayHeaderRowHeight - (weekRows * gridGap);
+    const dayCellHeight = Math.floor(contentHeight / weekRows);
+    const usableEventHeight = dayCellHeight - verticalPadding - dayNumberHeight;
+    if (!Number.isFinite(usableEventHeight) || usableEventHeight <= 0) {
+      return 1;
+    }
+
+    return Math.max(1, Math.floor(usableEventHeight / eventRowHeight));
+  }
+
   renderDay(dayNum, date, isOtherMonth) {
     const today = new Date();
     const isToday = date.toDateString() === today.toDateString();
@@ -2821,7 +2904,7 @@ class SkylightCalendarCard extends HTMLElement {
     
     dayEvents = this.sortEventsForDate(dayEvents, date);
     
-    const maxVisible = 3;
+    const maxVisible = this.getMaxVisibleEventsForMonthDay();
     
     let classes = 'day-cell';
     if (isOtherMonth) classes += ' other-month';


### PR DESCRIPTION
## Summary

This PR extends the existing `compact_height` functionality to the month view, enabling the calendar grid to dynamically size based on available viewport space.

### Key improvements

- Viewport-aware month sizing
  - Tracks the month grid’s position in the viewport to calculate accurate compact height.
  - Ensures the month view fills available space without overflowing.
- Flexible grid row layout
  - Dynamically sets `grid-template-rows` based on the number of visible week rows.
  - Prevents uneven spacing and improves visual consistency.
- Adaptive event visibility per day
  - Calculates how many events can fit in each day cell based on available height.
  - Eliminates hardcoded limits and improves usability on smaller displays.
- Improved resize responsiveness
  - Month view now re-renders when viewport size changes, matching week-standard behavior.
- CSS adjustments for compact month mode
  - Adds `.compact-month` styling to allow grid cells to shrink properly without layout issues.

### Result

Month view now behaves consistently with week-standard view in compact mode, providing a responsive, space-efficient layout that adapts to viewport size while maximizing visible event information.