### PR TITLE
Remove legacy `rolling_days` fallback (use per-view rolling_days_* only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ title: Next 7 Days
 entities:
   - calendar.family
 default_view: week-standard
-rolling_days: 6  # Show today + 6 more days = 7 total days
+rolling_days_schedule: 6  # Schedule view: show today + 6 more days = 7 total days
 week_start_hour: 6
 week_end_hour: 22
 height_scale: 0.5
@@ -160,7 +160,8 @@ rolling_weeks: 3  # Show current + 3 more weeks (28 days)
 | `header_color` | string | `'var(--primary-color)'` | Custom header background (solid color or gradient) |
 | `first_day_of_week` | integer | `0` | First day of week (0 = Sunday, 1 = Monday, etc.) |
 | `week_days` | list | `[0,1,2,3,4,5,6]` | Days to show in week views (0=Sun, 6=Sat) |
-| `rolling_days` | integer | `null` | Show today + N days (alternative to week_days) |
+| `rolling_days_week_compact` | integer | `null` | Compact week view: show today + N days (alternative to week_days) |
+| `rolling_days_schedule` | integer | `null` | Schedule view: show today + N days (alternative to week_days) |
 | `rolling_weeks` | integer | `null` | Show this week + N weeks in month view |
 | `week_start_hour` | integer | `8` | Start hour for week-standard view (0-23) |
 | `week_end_hour` | integer | `21` | End hour for week-standard view (0-23) |
@@ -491,7 +492,7 @@ title: Today's Tasks
 entities:
   - calendar.tasks
 default_view: week-compact
-rolling_days: 0  # Show only today
+rolling_days_week_compact: 0  # Show only today in compact week view
 enable_event_management: true
 ```
 
@@ -555,17 +556,18 @@ compact_height: true
 Perfect for dynamic date ranges that don't follow calendar weeks:
 
 ```yaml
-# Show next 3 days
-rolling_days: 2  # Today + 2 = 3 days
+# Compact week view: show next 3 days
+rolling_days_week_compact: 2  # Today + 2 = 3 days
 
-# Show next 10 days
-rolling_days: 9  # Today + 9 = 10 days
+# Schedule view: show next 10 days
+rolling_days_schedule: 9  # Today + 9 = 10 days
 
-# Show just today
-rolling_days: 0  # Today only
+# Show just today in both week views
+rolling_days_week_compact: 0
+rolling_days_schedule: 0
 ```
 
-Navigation buttons will advance by the number of days shown (rolling_days + 1).
+Navigation buttons advance by the number of days shown in the active view (`rolling_days_* + 1`).
 
 ### Using Rolling Weeks Mode
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -381,7 +381,8 @@ class SkylightCalendarCard extends HTMLElement {
       view_mode: config.view_mode || 'month', // 'month', 'week-compact', 'week-standard'
       default_view: config.default_view || config.view_mode || 'month', // Default view on load
       week_days: config.week_days || [0, 1, 2, 3, 4, 5, 6], // Which days to show in week view
-      rolling_days: config.rolling_days || null, // If set, show current day + N days instead of week_days
+      rolling_days_week_compact: config.rolling_days_week_compact ?? null, // If set, compact week view shows current day + N days instead of week_days
+      rolling_days_schedule: config.rolling_days_schedule ?? null, // If set, schedule week view shows current day + N days instead of week_days
       rolling_weeks: config.rolling_weeks || null, // If set, show current week + N weeks in month view
       week_start_hour: config.week_start_hour || 8, // Start hour for week-standard view
       week_end_hour: config.week_end_hour || 21, // End hour for week-standard view (9pm)
@@ -850,14 +851,28 @@ class SkylightCalendarCard extends HTMLElement {
     this._weekStart = date;
   }
 
-  getWeekDays() {
-    // If rolling_days is set, show current date + N days
-    if (this._config.rolling_days !== null) {
+  getRollingDaysForView(viewMode = this._viewMode) {
+    if (viewMode === 'week-compact' && this._config.rolling_days_week_compact !== null) {
+      return this._config.rolling_days_week_compact;
+    }
+
+    if (viewMode === 'week-standard' && this._config.rolling_days_schedule !== null) {
+      return this._config.rolling_days_schedule;
+    }
+
+    return null;
+  }
+
+  getWeekDays(viewMode = this._viewMode) {
+    const rollingDays = this.getRollingDaysForView(viewMode);
+
+    // If rolling days are set, show current date + N days
+    if (rollingDays !== null) {
       const days = [];
       const startDate = new Date(this._currentDate);
       startDate.setHours(0, 0, 0, 0);
       
-      for (let i = 0; i <= this._config.rolling_days; i++) {
+      for (let i = 0; i <= rollingDays; i++) {
         const date = new Date(startDate);
         date.setDate(startDate.getDate() + i);
         days.push(date);
@@ -3066,12 +3081,13 @@ class SkylightCalendarCard extends HTMLElement {
           this._currentDate.setMonth(this._currentDate.getMonth() - 1);
         }
       } else {
-        // In rolling_days mode, advance by rolling_days + 1, otherwise by 7
-        const daysToAdvance = this._config.rolling_days !== null 
-          ? this._config.rolling_days + 1 
+        // In rolling-days mode, advance by rolling days + 1, otherwise by 7
+        const rollingDays = this.getRollingDaysForView();
+        const daysToAdvance = rollingDays !== null
+          ? rollingDays + 1
           : 7;
         this._currentDate.setDate(this._currentDate.getDate() - daysToAdvance);
-        if (this._config.rolling_days === null) {
+        if (rollingDays === null) {
           this.setWeekStart();
         }
       }
@@ -3089,12 +3105,13 @@ class SkylightCalendarCard extends HTMLElement {
           this._currentDate.setMonth(this._currentDate.getMonth() + 1);
         }
       } else {
-        // In rolling_days mode, advance by rolling_days + 1, otherwise by 7
-        const daysToAdvance = this._config.rolling_days !== null 
-          ? this._config.rolling_days + 1 
+        // In rolling-days mode, advance by rolling days + 1, otherwise by 7
+        const rollingDays = this.getRollingDaysForView();
+        const daysToAdvance = rollingDays !== null
+          ? rollingDays + 1
           : 7;
         this._currentDate.setDate(this._currentDate.getDate() + daysToAdvance);
-        if (this._config.rolling_days === null) {
+        if (rollingDays === null) {
           this.setWeekStart();
         }
       }
@@ -3103,7 +3120,7 @@ class SkylightCalendarCard extends HTMLElement {
     
     todayButton?.addEventListener('click', () => {
       this._currentDate = new Date();
-      if (this._config.rolling_days === null) {
+      if (this.getRollingDaysForView() === null) {
         this.setWeekStart();
       }
       this.ensureEventsForCurrentRange({ renderIfCovered: true });


### PR DESCRIPTION
### Motivation
- Enforce explicit per-view configuration by removing the legacy `rolling_days` fallback so `week-compact` and `week-standard` must use `rolling_days_week_compact` and `rolling_days_schedule` respectively.
- Avoid ambiguity where a single legacy key applied to both week views and simplify the date-range resolution logic.

### Description
- Removed the `rolling_days` entry from `setConfig` and the runtime config so only `rolling_days_week_compact` and `rolling_days_schedule` remain in `skylight-calendar-card.js`.
- Kept and used `getRollingDaysForView(viewMode)` as the single source of truth for per-view rolling-days and made it return `null` when no per-view value is present.
- Updated `getWeekDays` and all navigation/today handlers to call `getRollingDaysForView()` instead of referencing a legacy `_config.rolling_days` value.
- Updated `README.md` to remove the legacy `rolling_days` documentation and to show examples using `rolling_days_week_compact` and `rolling_days_schedule` only.

### Testing
- Ran `node --check skylight-calendar-card.js` to validate file syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992369d274c8331a44615bb2fd9558f)