### PR TITLE
Scope calendar preference persistence per dashboard

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -470,6 +470,70 @@ class SkylightCalendarCard extends HTMLElement {
     };
   }
 
+  getDashboardScopeKey() {
+    const pathnameSegments = (window.location?.pathname || '').split('/').filter(Boolean);
+    if (pathnameSegments.length > 0) {
+      return pathnameSegments[0];
+    }
+
+    const hashPath = (window.location?.hash || '').replace(/^#/, '');
+    const hashSegments = hashPath.split('/').filter(Boolean);
+    if (hashSegments.length > 0) {
+      return hashSegments[0];
+    }
+
+    return 'default';
+  }
+
+  getPreferenceStorageKey() {
+    const dashboardScope = this.getDashboardScopeKey();
+    const baseKey = this._config.preference_storage_key || (this._config.entities || []).join('|');
+
+    if (!baseKey) {
+      return null;
+    }
+
+    return `skylight-calendar-card:${dashboardScope}:${baseKey}`;
+  }
+
+  loadPersistedPreferences() {
+    const storageKey = this.getPreferenceStorageKey();
+    if (!storageKey) return;
+
+    try {
+      const raw = window.localStorage?.getItem(storageKey);
+      if (!raw) return;
+
+      const parsed = JSON.parse(raw);
+
+      if (typeof parsed.isDarkMode === 'boolean') {
+        this._isDarkMode = parsed.isDarkMode;
+      }
+
+      if (Array.isArray(parsed.hiddenCalendars)) {
+        const knownEntities = new Set(this._config.entities || []);
+        this._hiddenCalendars = new Set(parsed.hiddenCalendars.filter((entityId) => knownEntities.has(entityId)));
+      }
+    } catch (error) {
+      console.warn('Failed to load persisted calendar preferences:', error);
+    }
+  }
+
+  persistPreferences() {
+    const storageKey = this.getPreferenceStorageKey();
+    if (!storageKey) return;
+
+    try {
+      const payload = {
+        isDarkMode: this._isDarkMode,
+        hiddenCalendars: Array.from(this._hiddenCalendars)
+      };
+      window.localStorage?.setItem(storageKey, JSON.stringify(payload));
+    } catch (error) {
+      console.warn('Failed to persist calendar preferences:', error);
+    }
+  }
+
   updateCompactHeaderWrapState() {
     if (!this.shadowRoot || !this._config.compact_header) return;
 
@@ -522,6 +586,7 @@ class SkylightCalendarCard extends HTMLElement {
     }
     const language = resolveLanguage(config.language || this._hass?.language || this._hass?.locale?.language);
     this._hasCustomTitle = config.title !== undefined && config.title !== null;
+    const previousHiddenCalendars = new Set(this._hiddenCalendars);
     this._config = {
       title: this._hasCustomTitle ? config.title : translate(language, 'defaultTitle'),
       entities: config.entities,
@@ -550,10 +615,15 @@ class SkylightCalendarCard extends HTMLElement {
       language: config.language || null, // Language code for translations (e.g., 'en', 'de', 'fr')
       locale: config.locale || null, // Locale override for date/time formatting (e.g., 'en-US')
       default_dark_mode: config.default_dark_mode ?? config.dark_mode ?? false, // Start in dark mode on initial load
+      preference_storage_key: config.preference_storage_key || null, // Optional key to isolate saved preferences per card
       ...config
     };
     this._viewMode = this._config.default_view;
     this._isDarkMode = !!this._config.default_dark_mode;
+    this._hiddenCalendars = new Set(
+      Array.from(previousHiddenCalendars).filter((entityId) => this._config.entities.includes(entityId))
+    );
+    this.loadPersistedPreferences();
     this._loadedEventRange = null;
     this.setWeekStart();
     this.render();
@@ -3274,6 +3344,7 @@ class SkylightCalendarCard extends HTMLElement {
         } else {
           this._hiddenCalendars.add(entityId);
         }
+        this.persistPreferences();
         this.render();
       });
     });
@@ -3285,6 +3356,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     themeToggleButton?.addEventListener('click', () => {
       this._isDarkMode = !this._isDarkMode;
+      this.persistPreferences();
       this.render();
     });
     


### PR DESCRIPTION
### Motivation

- Added preference persistence helpers that save and restore dark mode plus hidden calendar filters using localStorage, with safe parsing and fallback behavior. 
- Updated configuration setup to load persisted preferences on card init, while still respecting default_dark_mode when no saved value exists, and added optional preference_storage_key to scope storage per card instance. 
- Wired persistence into UI interactions so both calendar badge filtering and theme toggling are saved immediately and survive refreshes. 
- Ensure dark mode and calendar filter preferences are isolated per dashboard so settings don't bleed between dashboards on the same Home Assistant instance.
- Provide a stable, per-dashboard namespace while preserving the existing `preference_storage_key` override and previous fallback behavior.

### Description

- Added `getDashboardScopeKey()` to derive a dashboard scope from the current URL path or hash and fall back to `'default'` when none is found.
- Updated `getPreferenceStorageKey()` to combine the dashboard scope with the configured `preference_storage_key` or the `entities`-based key so stored preferences are namespaced per dashboard via keys like `skylight-calendar-card:<dashboard>:<baseKey>`.
- Kept preference load/save logic in `loadPersistedPreferences()` and `persistPreferences()` and adjusted `setConfig()` to preserve only hidden calendars that belong to the current `entities` list before loading persisted preferences.
- Persist preferences immediately when toggling dark mode or calendar badges by calling `persistPreferences()` where toggles occur.