### PR TITLE
Add event font customization options.

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1488,6 +1488,7 @@ class SkylightCalendarCard extends HTMLElement {
         padding: 4px 6px;
         border-radius: 4px;
         font-size: var(--event-bubble-font-size, 11px);
+        line-height: 1.2;
         margin-bottom: 3px;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -3315,6 +3316,37 @@ class SkylightCalendarCard extends HTMLElement {
     return Math.ceil((startDay + daysInMonth) / 7);
   }
 
+  getEventBubbleFontSizePx() {
+    const fallbackPx = 11;
+    const sizeValue = this.getEventBubbleFontSize();
+
+    if (typeof window === 'undefined' || !this.shadowRoot) {
+      const parsed = parseFloat(sizeValue);
+      return Number.isFinite(parsed) ? parsed : fallbackPx;
+    }
+
+    const probe = document.createElement('span');
+    probe.style.position = 'absolute';
+    probe.style.visibility = 'hidden';
+    probe.style.fontSize = sizeValue;
+    probe.style.lineHeight = 'normal';
+    probe.textContent = 'M';
+    this.shadowRoot.appendChild(probe);
+
+    const computedFontSize = parseFloat(window.getComputedStyle(probe).fontSize);
+    probe.remove();
+
+    return Number.isFinite(computedFontSize) ? computedFontSize : fallbackPx;
+  }
+
+  getMonthEventRowHeight() {
+    const fontSizePx = this.getEventBubbleFontSizePx();
+    const lineHeightPx = fontSizePx * 1.2;
+    const verticalPaddingPx = 8; // .event has 4px top + 4px bottom padding
+    const marginBottomPx = 3; // .event margin-bottom in month view
+    return Math.ceil(lineHeightPx + verticalPaddingPx + marginBottomPx);
+  }
+
   renderDays() {
     const year = this._currentDate.getFullYear();
     const month = this._currentDate.getMonth();
@@ -3411,14 +3443,16 @@ class SkylightCalendarCard extends HTMLElement {
 
     const gridGap = 1;
     const dayHeaderRowHeight = 41;
-    const verticalPadding = 16;
-    const dayNumberHeight = 32;
-    const eventRowHeight = 22;
-    const moreIndicatorHeight = 16;
+    const dayCellVerticalPadding = 16; // .day-cell has 8px top + 8px bottom padding
+    const dayNumberBlockHeight = 22; // number text + margin-bottom in compact month cell
+    const eventRowHeight = this.getMonthEventRowHeight();
 
     const contentHeight = compactMaxHeight - dayHeaderRowHeight - (weekRows * gridGap);
     const dayCellHeight = Math.floor(contentHeight / weekRows);
-    const usableEventHeight = dayCellHeight - verticalPadding - dayNumberHeight - moreIndicatorHeight;
+    // Do not pre-reserve space for the "+N more" indicator here. Overflow handling
+    // swaps one event row for the indicator in renderDay(), so reserving both causes
+    // under-counting and hidden space.
+    const usableEventHeight = dayCellHeight - dayCellVerticalPadding - dayNumberBlockHeight;
     if (!Number.isFinite(usableEventHeight) || usableEventHeight <= 0) {
       return 1;
     }


### PR DESCRIPTION
## Summary
* Added two new card config options in setConfig: event_font_size (global for all calendars/views) and event_font_colors (per-calendar text color map with fallback to white).
* Updated event bubble CSS to use overridable CSS variables for text color and font size in month, compact week, all-day schedule, and timed schedule bubbles, and switched time text sizing to relative units so the configured font size scales cleanly across views.
* Applied the new font size/color variables at render-time for event bubbles in all relevant views (month, compact week, schedule all-day, schedule timed, and compact day modal).
* Added helper methods to normalize font-size input (number, numeric string, or CSS size string) and resolve per-calendar font color with a white fallback.
* Updated stub config defaults to include event_font_size and event_font_colors.