### PR TITLE
Keep next-month weeks active in rolling month view

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3415,8 +3415,10 @@ class SkylightCalendarCard extends HTMLElement {
       const date = new Date(weekStart);
       date.setDate(weekStart.getDate() + i);
       
-      // Check if this day is in a different month than the reference date (for styling)
-      const isOtherMonth = date.getMonth() !== this._currentDate.getMonth();
+      // In rolling-weeks month view, keep trailing (next-month) days visually active
+      // while still dimming any leading days from the previous month.
+      const currentMonthStart = new Date(this._currentDate.getFullYear(), this._currentDate.getMonth(), 1);
+      const isOtherMonth = date < currentMonthStart;
       
       html += this.renderDay(date.getDate(), date, isOtherMonth);
     }


### PR DESCRIPTION
### Motivation

- Maintain the existing behavior where weeks that fall into the next month are shown active (not grayed) when `rolling_weeks` is configured, while still dimming leading days from the previous month.

### Description

- Updated `renderRollingWeeks()` in `skylight-calendar-card.js` to compute `isOtherMonth` by testing whether a day is before the current month's start instead of comparing month numbers, so trailing next-month days remain visually active.
- The change only affects month view when `rolling_weeks` is set and preserves standard (non-rolling) month view behavior.

### Testing

- Ran `node --check skylight-calendar-card.js`, which completed successfully.
- Attempted a Playwright-based screenshot validation, but the Chromium process crashed in this environment (SIGSEGV), so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a26e36fde883318ddeecd0177145c6)