### PR TITLE
Add support for combining identical events across calendars with zebra-striping and bulk edit/delete

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4503,6 +4503,14 @@ class SkylightCalendarCard extends HTMLElement {
       this.showError(this.t('noWritableCalendars'));
       return;
     }
+
+    const selectedEditTargets = Array.isArray(this._combinedEditTargets) && this._combinedEditTargets.length > 0
+      ? this._combinedEditTargets
+      : null;
+    const selectedCombinedCalendarIds = selectedEditTargets
+      ? Array.from(new Set(selectedEditTargets.map(target => target.entityId))).filter((entityId) => writableCalendars.includes(entityId))
+      : [];
+    const visibleCalendarOptions = selectedCombinedCalendarIds.length > 0 ? selectedCombinedCalendarIds : writableCalendars;
     
     // Format for datetime-local input
     const formatDateTimeLocal = (date) => {
@@ -4537,8 +4545,8 @@ class SkylightCalendarCard extends HTMLElement {
             <label class="form-label">
               ${this.t('calendar')}<span class="form-required">*</span>
             </label>
-            <select class="form-select" id="event-calendar" required>
-              ${writableCalendars.map((entityId) => `
+            <select class="form-select" id="event-calendar" required ${selectedCombinedCalendarIds.length > 1 ? 'disabled' : ''}>
+              ${visibleCalendarOptions.map((entityId) => `
                 <option value="${entityId}" ${entityId === event.entityId ? 'selected' : ''}>
                   ${this.escapeHtml(this.getCalendarName(entityId))}
                 </option>


### PR DESCRIPTION
### Motivation

- Reduce visual duplication when the same event appears in multiple calendars by combining identical events into a single entry with per-calendar visual cues. 
- Allow editing/deleting of calendar copies in bulk while still honoring hidden calendars and calendar-specific display preferences.
- Improve visual clarity by adding zebra-striping for combined calendar colors and grouping calendar badges/icons for combined events.

### Description

- Add two new configuration options: `combine_calendars` (default `false`) and `combine_calendars_width` (default `12`) to enable combining identical events and configure stripe width. 
- Implement event normalization and exact-match key generation (`normalizeEventTextValue`, `getNormalizedEventTimeValue`, `getEventExactMatchKey`) and grouping logic (`combineDuplicateCalendarEvents`) that produces combined events annotated with `isCombinedCalendarEvent`, `sourceCalendars`, `sourceEntityIds`, and `sourceEvents`.
- Render combined events using `getEventStyle` which generates either a single-color background or a zebra-striped `repeating-linear-gradient` via `createZebraStripeGradient`, and update all views to use this styling for month, week-compact, week-standard, all-day, and timed events.
- Update icon/badge rendering (`renderEventIcon`, `getVisibleCalendarBadgesForEvent`) and font/color/time visibility logic (`getEventBubbleFontColor`, `shouldShowEventTime`, `getVisibleCalendarColorsForEvent`) to respect combined events and hidden calendars.
- Add UI flows for selecting which calendar copies to edit or delete: `showCombinedEditSelectionModal`, `showCombinedDeleteSelectionModal`, and wire these into the event modal and the edit/delete handlers; track user selections using `_combinedEditTargets` and `_combinedDeleteTargets` and perform batch update/delete operations accordingly.
- Use combined-event-aware filtering when building day events (`getEventsForDay`) so hidden calendars are respected when events are combined, and make small styling/CSS adjustments for grouped icons.

### Testing

- Ran `npm run lint` and static checks which passed. 
- Built the bundle with `npm run build` successfully. 
- Ran automated unit tests with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5f5de7c948331804e37de92410ed6)