### PR TITLE
Fix DST shift in schedule timed event layout

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3148,10 +3148,8 @@ class SkylightCalendarCard extends HTMLElement {
     // Process timed events for overlaps
     const eventBlocks = timedEvents.map(({ event, daySegment }) => {
       const { segmentStart, segmentEnd } = daySegment;
-      const dayStart = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-
-      const startHourFloat = (segmentStart.getTime() - dayStart.getTime()) / 3600000;
-      const endHourFloat = (segmentEnd.getTime() - dayStart.getTime()) / 3600000;
+      const startHourFloat = this.getLocalDayHourFloat(segmentStart, date);
+      const endHourFloat = this.getLocalDayHourFloat(segmentEnd, date);
       
       return {
         event,
@@ -3255,6 +3253,20 @@ class SkylightCalendarCard extends HTMLElement {
         </div>
       `;
     }).join('');
+  }
+
+  getLocalDayHourFloat(dateTime, referenceDate) {
+    // Use wall-clock hour values relative to the rendered day so DST transitions
+    // do not visually shift events by ±1 hour in the schedule grid.
+    const dayKey = Date.UTC(referenceDate.getFullYear(), referenceDate.getMonth(), referenceDate.getDate());
+    const timeKey = Date.UTC(dateTime.getFullYear(), dateTime.getMonth(), dateTime.getDate());
+    const dayDiff = (timeKey - dayKey) / 86400000;
+
+    return (dayDiff * 24) +
+      dateTime.getHours() +
+      (dateTime.getMinutes() / 60) +
+      (dateTime.getSeconds() / 3600) +
+      (dateTime.getMilliseconds() / 3600000);
   }
 
   getVisibleCalendarBadgesForEvent(event) {


### PR DESCRIPTION
### Motivation
- Timed events rendered in the schedule/week view could appear shifted by ±1 hour on daylight savings transition days due to using elapsed milliseconds from midnight when computing visual positions. 
- The goal is to compute event positions using stable wall-clock hours relative to the displayed day so events at e.g. `12:00` and `14:00` remain in their expected slots even on 23/25-hour days.

### Description
- Replaced elapsed-time-from-midnight calculations in `renderTimedEventsForDay` with calls to a new helper `getLocalDayHourFloat()` to compute hour floats relative to the rendered day.
- Implemented `getLocalDayHourFloat(dateTime, referenceDate)` which returns a wall-clock hour offset (including minutes/seconds/milliseconds) and correctly accounts for multi-day differences without introducing DST-induced visual shifts.
- Changed only `skylight-calendar-card.js` to use the helper for `startHourFloat` and `endHourFloat` calculations used by the schedule layout and overlap clustering logic.

### Testing
- Ran syntax check with `node --check skylight-calendar-card.js`, which completed successfully.