### PR TITLE
Add rich editor UI with color picker, calendar-specific mappings, and improved state handling

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -6063,9 +6063,19 @@ class SkylightCalendarCardEditor extends HTMLElement {
     this._hass = null;
     this._rendered = false;
     this._lastCalendarEntitiesKey = '';
+    this._colorPickerState = {
+      open: false,
+      field: null,
+      mapKey: null,
+      h: 0,
+      s: 1,
+      v: 1,
+      color: '#3f51b5'
+    };
   }
 
   setConfig(config) {
+    const previousEntities = Array.isArray(this._config?.entities) ? this._config.entities : [];
     const normalizedDefaultView = config.default_view === 'week'
       ? 'week-compact'
       : config.default_view === 'schedule'
@@ -6079,6 +6089,14 @@ class SkylightCalendarCardEditor extends HTMLElement {
     };
 
     if (!this._rendered) {
+      this.render();
+      return;
+    }
+
+    const nextEntities = Array.isArray(this._config.entities) ? this._config.entities : [];
+    const entitiesChanged = previousEntities.join('|') !== nextEntities.join('|');
+
+    if (entitiesChanged) {
       this.render();
       return;
     }
@@ -6107,22 +6125,500 @@ class SkylightCalendarCardEditor extends HTMLElement {
       .sort();
   }
 
-  render() {
-    const boolOptions = [
-      { key: 'compact_height', label: 'Compact height' },
-      { key: 'compact_header', label: 'Compact header' },
-      { key: 'show_current_time_bar', label: 'Show current time bar' },
-      { key: 'use_24hr_schedule', label: 'Use 24-hour schedule time' },
-      { key: 'combine_calendars', label: 'Combine duplicate events across calendars' },
-      { key: 'enable_event_management', label: 'Enable event management' },
-      { key: 'default_dark_mode', label: 'Default dark mode' }
-    ];
+  escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
 
-    const boolOptionsMarkup = boolOptions
-      .map(({ key, label }) => `
-        <label><input type="checkbox" data-field="${key}" ${this._config[key] ? 'checked' : ''}> ${label}</label>
-      `)
+  normalizeDefaultViewForEditor(value) {
+    if (value === 'week') return 'week-compact';
+    if (value === 'schedule') return 'week-standard';
+    return value || 'month';
+  }
+
+  getMapFieldValue(key) {
+    const value = this._config[key];
+    return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+  }
+
+  getListFieldValue(key) {
+    const value = this._config[key];
+    return Array.isArray(value) ? value : [];
+  }
+
+  getListInputValue(key) {
+    return this.getListFieldValue(key).join(', ');
+  }
+
+
+  getEditorDefaultValue(key) {
+    const defaults = {
+      week_start_hour: 8,
+      week_end_hour: 21,
+      height_scale: 1,
+      event_font_size: 11,
+      combine_calendars_width: 12,
+      max_events: 0,
+      first_day_of_week: 0
+    };
+    return Object.prototype.hasOwnProperty.call(defaults, key) ? defaults[key] : 0;
+  }
+
+  getConfiguredEntitiesForEditor() {
+    const entities = Array.isArray(this._config.entities) ? this._config.entities : [];
+    return entities.filter((entityId) => typeof entityId === 'string' && entityId.startsWith('calendar.'));
+  }
+
+  getEntityFriendlyName(entityId) {
+    return this._hass?.states?.[entityId]?.attributes?.friendly_name || entityId;
+  }
+
+  toColorInputValue(value, fallback = '#3f51b5') {
+    const normalized = String(value || '').trim();
+    if (/^#[0-9a-fA-F]{6}$/.test(normalized)) {
+      return normalized;
+    }
+    return fallback;
+  }
+
+  hexToHsv(hex) {
+    const normalizedHex = this.toColorInputValue(hex).replace('#', '');
+    const r = parseInt(normalizedHex.slice(0, 2), 16) / 255;
+    const g = parseInt(normalizedHex.slice(2, 4), 16) / 255;
+    const b = parseInt(normalizedHex.slice(4, 6), 16) / 255;
+
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const delta = max - min;
+
+    let h = 0;
+    if (delta !== 0) {
+      if (max === r) h = ((g - b) / delta) % 6;
+      else if (max === g) h = (b - r) / delta + 2;
+      else h = (r - g) / delta + 4;
+      h = Math.round(h * 60);
+      if (h < 0) h += 360;
+    }
+
+    const s = max === 0 ? 0 : delta / max;
+    const v = max;
+    return { h, s, v };
+  }
+
+  hsvToHex(h, s, v) {
+    const hue = ((h % 360) + 360) % 360;
+    const sat = Math.max(0, Math.min(1, s));
+    const val = Math.max(0, Math.min(1, v));
+
+    const c = val * sat;
+    const x = c * (1 - Math.abs(((hue / 60) % 2) - 1));
+    const m = val - c;
+
+    let r = 0;
+    let g = 0;
+    let b = 0;
+
+    if (hue < 60) [r, g, b] = [c, x, 0];
+    else if (hue < 120) [r, g, b] = [x, c, 0];
+    else if (hue < 180) [r, g, b] = [0, c, x];
+    else if (hue < 240) [r, g, b] = [0, x, c];
+    else if (hue < 300) [r, g, b] = [x, 0, c];
+    else [r, g, b] = [c, 0, x];
+
+    const toHex = (n) => Math.round((n + m) * 255).toString(16).padStart(2, '0');
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+  }
+
+  getColorValue(field, mapKey = null) {
+    if (mapKey) {
+      return this.toColorInputValue(this.getMapFieldValue(field)[mapKey]);
+    }
+    return this.toColorInputValue(this._config[field]);
+  }
+
+  emitConfigChanged(nextConfig) {
+    this._config = nextConfig;
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config: nextConfig },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  openColorPicker(field, mapKey = null) {
+    const initialColor = this.getColorValue(field, mapKey);
+    const hsv = this.hexToHsv(initialColor);
+    this._colorPickerState = {
+      open: true,
+      field,
+      mapKey,
+      h: hsv.h,
+      s: hsv.s,
+      v: hsv.v,
+      color: initialColor
+    };
+
+    const dialog = this.querySelector('.color-picker-dialog');
+    if (dialog) {
+      dialog.classList.add('show');
+      this.syncColorPickerUi();
+    }
+  }
+
+  closeColorPicker() {
+    this._colorPickerState.open = false;
+    const dialog = this.querySelector('.color-picker-dialog');
+    if (dialog) dialog.classList.remove('show');
+  }
+
+  syncColorPickerUi() {
+    const dialog = this.querySelector('.color-picker-dialog');
+    if (!dialog) return;
+
+    const { h, s, v, color } = this._colorPickerState;
+    const marker = dialog.querySelector('.color-picker-wheel-marker');
+    const brightnessInput = dialog.querySelector('#color-picker-brightness');
+    const hexInput = dialog.querySelector('#color-picker-hex');
+    const preview = dialog.querySelector('.color-picker-preview');
+    const valueText = dialog.querySelector('.color-picker-value');
+
+    if (marker) {
+      const radius = 120;
+      const angle = ((h - 90) * Math.PI) / 180;
+      const markerRadius = s * radius;
+      const x = Math.cos(angle) * markerRadius;
+      const y = Math.sin(angle) * markerRadius;
+      marker.style.left = `calc(50% + ${x}px)`;
+      marker.style.top = `calc(50% + ${y}px)`;
+    }
+
+    if (brightnessInput) brightnessInput.value = String(Math.round(v * 100));
+    if (hexInput && document.activeElement !== hexInput) hexInput.value = color;
+    if (preview) preview.style.background = color;
+    if (valueText) valueText.textContent = color;
+  }
+
+  updateColorPickerFromWheelEvent(event) {
+    const wheel = event.currentTarget;
+    const rect = wheel.getBoundingClientRect();
+    const x = event.clientX - rect.left - rect.width / 2;
+    const y = event.clientY - rect.top - rect.height / 2;
+    const radius = rect.width / 2;
+    const distance = Math.min(Math.sqrt(x * x + y * y), radius);
+    const saturation = distance / radius;
+    const hue = (Math.atan2(y, x) * 180) / Math.PI + 90;
+
+    this._colorPickerState.h = hue < 0 ? hue + 360 : hue;
+    this._colorPickerState.s = saturation;
+    this._colorPickerState.color = this.hsvToHex(this._colorPickerState.h, this._colorPickerState.s, this._colorPickerState.v);
+    this.syncColorPickerUi();
+  }
+
+  applyColorPickerColor(hexColor) {
+    const { field, mapKey } = this._colorPickerState;
+    if (!field) return;
+
+    const nextConfig = { ...this.value };
+    if (mapKey) {
+      nextConfig[field] = {
+        ...this.getMapFieldValue(field),
+        [mapKey]: hexColor
+      };
+    } else {
+      nextConfig[field] = hexColor;
+    }
+
+    this.emitConfigChanged(nextConfig);
+    this.updateFieldValues();
+    this.closeColorPicker();
+  }
+
+  normalizeHexColorInput(value) {
+    const raw = String(value || '').trim();
+    if (!raw) return null;
+    const withHash = raw.startsWith('#') ? raw : `#${raw}`;
+    return /^#[0-9a-fA-F]{6}$/.test(withHash) ? withHash.toLowerCase() : null;
+  }
+
+  renderColorPickerDialog() {
+    return `
+      <div class="color-picker-dialog">
+        <div class="color-picker-overlay" data-close-color-picker="true"></div>
+        <div class="color-picker-modal" role="dialog" aria-label="Select color">
+          <div class="color-picker-title">Select color</div>
+          <div class="color-picker-wheel" id="color-picker-wheel">
+            <div class="color-picker-wheel-marker"></div>
+          </div>
+          <div class="color-picker-controls">
+            <label for="color-picker-brightness">Color brightness</label>
+            <input id="color-picker-brightness" type="range" min="5" max="100" step="1">
+          </div>
+          <div class="color-picker-controls">
+            <label for="color-picker-hex">Hex color</label>
+            <input id="color-picker-hex" type="text" placeholder="#3f51b5">
+          </div>
+          <div class="color-picker-presets">
+            ${['#ffffff', '#ff0000', '#ffff00', '#00ff00', '#000000', '#00ffff', '#0000ff', '#ff00ff']
+              .map((color) => `<button type="button" class="color-preset" data-color-preset="${color}" style="background:${color}"></button>`)
+              .join('')}
+          </div>
+          <div class="color-picker-selected-row">
+            <span>Chosen color</span>
+            <span class="color-picker-preview"></span>
+            <span class="color-picker-value"></span>
+          </div>
+          <div class="color-picker-actions">
+            <button type="button" data-close-color-picker="true">Cancel</button>
+            <button type="button" class="primary" id="apply-color-picker">Set</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  renderColorInputControl({ id, field, mapKey = null, value }) {
+    const colorValue = this.toColorInputValue(value);
+    const triggerAttributes = mapKey
+      ? `data-color-trigger="true" data-color-field="${field}" data-color-map-key="${mapKey}"`
+      : `data-color-trigger="true" data-color-field="${field}"`;
+
+    return `
+      <div class="color-picker-wrap">
+        <button id="${id}" class="selected-color-swatch" data-color-field="${field}" ${mapKey ? `data-color-map-key="${mapKey}"` : ''} ${triggerAttributes} style="--selected-color: ${colorValue};" title="Choose color" type="button"></button>
+      </div>
+    `;
+  }
+
+  renderMapRowInputs(mapKey, { label, inputType = 'text', placeholder = '' } = {}) {
+    const mapValue = this.getMapFieldValue(mapKey);
+    const entities = this.getConfiguredEntitiesForEditor();
+
+    if (!entities.length) {
+      return `<p class="helper">Select at least one calendar to configure ${label || mapKey}.</p>`;
+    }
+
+    return entities
+      .map((entityId) => {
+        const displayName = this.escapeHtml(this.getEntityFriendlyName(entityId));
+        const value = mapValue[entityId] || '';
+        if (inputType === 'color') {
+          return `
+            <div class="map-row">
+              <label class="map-label" for="${mapKey}-${entityId}">${displayName}</label>
+              ${this.renderColorInputControl({ id: `${mapKey}-${entityId}`, field: mapKey, mapKey: entityId, value })}
+            </div>
+          `;
+        }
+
+        return `
+          <div class="map-row">
+            <label class="map-label" for="${mapKey}-${entityId}">${displayName}</label>
+            <input id="${mapKey}-${entityId}" type="text" data-map-field="${mapKey}" data-map-key="${entityId}" value="${this.escapeHtml(value)}" placeholder="${placeholder}">
+          </div>
+        `;
+      })
       .join('');
+  }
+
+  renderCalendarListCheckboxes(field, { label }) {
+    const entities = this.getConfiguredEntitiesForEditor();
+    const selectedValues = new Set(this.getListFieldValue(field));
+
+    if (!entities.length) {
+      return `<p class="helper">Select at least one calendar to configure ${label || field}.</p>`;
+    }
+
+    return entities
+      .map((entityId) => {
+        const displayName = this.escapeHtml(this.getEntityFriendlyName(entityId));
+        const checked = selectedValues.has(entityId) ? 'checked' : '';
+        return `
+          <label class="list-checkbox-row">
+            <span>${displayName}</span>
+            <input type="checkbox" data-list-field="${field}" value="${entityId}" ${checked}>
+          </label>
+        `;
+      })
+      .join('');
+  }
+
+  renderSection(title, content) {
+    return `
+      <details class="config-section">
+        <summary>${title}</summary>
+        <div class="section-content">${content}</div>
+      </details>
+    `;
+  }
+
+  renderSubSection(title, content) {
+    return `
+      <details class="config-subsection">
+        <summary>${title}</summary>
+        <div class="subsection-content">${content}</div>
+      </details>
+    `;
+  }
+
+  renderWeekdayCheckboxes() {
+    const selectedWeekdays = new Set(this.getListFieldValue('week_days'));
+    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+    return `
+      <div class="weekday-grid" role="group" aria-label="Week days">
+        ${days.map((day) => `<span class="weekday-label">${day}</span>`).join('')}
+        ${days.map((_, index) => `
+          <label class="weekday-checkbox-wrap" aria-label="${days[index]}">
+            <input type="checkbox" data-weekday="${index}" ${selectedWeekdays.has(index) ? 'checked' : ''}>
+          </label>
+        `).join('')}
+      </div>
+    `;
+  }
+
+  render() {
+    const displayLayoutSection = this.renderSection('Display & layout', `
+      <div class="field">
+        <label for="first_day_of_week">First day of week</label>
+        <select id="first_day_of_week" data-field="first_day_of_week" data-type="number">
+          <option value="0" ${Number(this._config.first_day_of_week) === 0 ? 'selected' : ''}>Sunday</option>
+          <option value="1" ${Number(this._config.first_day_of_week) === 1 ? 'selected' : ''}>Monday</option>
+          <option value="2" ${Number(this._config.first_day_of_week) === 2 ? 'selected' : ''}>Tuesday</option>
+          <option value="3" ${Number(this._config.first_day_of_week) === 3 ? 'selected' : ''}>Wednesday</option>
+          <option value="4" ${Number(this._config.first_day_of_week) === 4 ? 'selected' : ''}>Thursday</option>
+          <option value="5" ${Number(this._config.first_day_of_week) === 5 ? 'selected' : ''}>Friday</option>
+          <option value="6" ${Number(this._config.first_day_of_week) === 6 ? 'selected' : ''}>Saturday</option>
+        </select>
+      </div>
+      <div class="field">
+        <label>Week days</label>
+        ${this.renderWeekdayCheckboxes()}
+      </div>
+      <div class="field-row">
+        <div class="field">
+          <label for="week_start_hour">Week start hour</label>
+          <input id="week_start_hour" data-field="week_start_hour" data-type="number" type="number" min="0" max="23" value="${Number(this._config.week_start_hour ?? this.getEditorDefaultValue('week_start_hour'))}">
+        </div>
+        <div class="field">
+          <label for="week_end_hour">Week end hour</label>
+          <input id="week_end_hour" data-field="week_end_hour" data-type="number" type="number" min="1" max="24" value="${Number(this._config.week_end_hour ?? this.getEditorDefaultValue('week_end_hour'))}">
+        </div>
+      </div>
+      <div class="field-row">
+        <div class="field">
+          <label for="rolling_days_week_compact">Rolling days (week view)</label>
+          <input id="rolling_days_week_compact" data-field="rolling_days_week_compact" data-type="nullable-number" type="number" min="1" value="${this._config.rolling_days_week_compact ?? ''}" placeholder="Disabled">
+        </div>
+        <div class="field">
+          <label for="rolling_days_schedule">Rolling days (schedule view)</label>
+          <input id="rolling_days_schedule" data-field="rolling_days_schedule" data-type="nullable-number" type="number" min="1" value="${this._config.rolling_days_schedule ?? ''}" placeholder="Disabled">
+        </div>
+      </div>
+      <div class="field">
+        <label for="rolling_weeks">Rolling weeks (month view)</label>
+        <input id="rolling_weeks" data-field="rolling_weeks" data-type="nullable-number" type="number" min="1" value="${this._config.rolling_weeks ?? ''}" placeholder="Disabled">
+      </div>
+      <div class="boolean-list">
+        <label><input type="checkbox" data-field="compact_height" ${this._config.compact_height ? 'checked' : ''}> Compact height</label>
+        <label><input type="checkbox" data-field="compact_header" ${this._config.compact_header ? 'checked' : ''}> Compact header</label>
+      </div>
+      ${this._config.compact_height ? '' : `
+        <div class="field">
+          <label for="height_scale">Height scale</label>
+          <input id="height_scale" data-field="height_scale" data-type="number" type="number" min="0.1" step="0.1" value="${Number(this._config.height_scale ?? this.getEditorDefaultValue('height_scale'))}">
+        </div>
+      `}
+    `);
+
+    const colorStylingSection = this.renderSection('Colors & styling', `
+      <div class="field field-inline">
+        <label for="header_color">Header color</label>
+        <div class="field-row">
+          ${this.renderColorInputControl({ id: 'header_color', field: 'header_color', value: this._config.header_color })}
+          <input data-field="header_color_text" data-type="color-text" type="text" value="${this.escapeHtml(this._config.header_color || '')}" placeholder="var(--primary-color)">
+        </div>
+      </div>
+      ${this.renderSubSection('Calendar colors', `<div class="map-grid">${this.renderMapRowInputs('colors', { label: 'calendar colors', inputType: 'color' })}</div>`)}
+      ${this.renderSubSection('Event font colors', `<div class="map-grid">${this.renderMapRowInputs('event_font_colors', { label: 'event font colors', inputType: 'color' })}</div>`)}
+      ${this.renderSubSection('Calendar display names', `<div class="map-grid">${this.renderMapRowInputs('calendar_names', { label: 'calendar names', placeholder: 'Display name' })}</div>`)}
+      ${this.renderSubSection('Calendar badge icons', `<div class="map-grid">${this.renderMapRowInputs('calendar_badge_icons', { label: 'badge icons', placeholder: 'mdi:icon or URL' })}</div>`)}
+      <div class="boolean-list">
+        <label><input type="checkbox" data-field="background_transparent" ${this._config.background_transparent ? 'checked' : ''}> Transparent background surfaces</label>
+        <label><input type="checkbox" data-field="default_dark_mode" ${this._config.default_dark_mode ? 'checked' : ''}> Default dark mode</label>
+      </div>
+    `);
+
+    const backgroundSection = this.renderSection('Background image', `
+      <div class="field field-inline">
+        <label for="background_image_url">Background image URL</label>
+        <input id="background_image_url" data-field="background_image_url" type="text" value="${this._config.background_image_url || ''}" placeholder="https://... or /media/local/...">
+      </div>
+      <div class="field-row">
+        <div class="field field-inline">
+          <label for="background_image_size">Image size</label>
+          <input id="background_image_size" data-field="background_image_size" type="text" value="${this._config.background_image_size || 'cover'}" placeholder="cover">
+        </div>
+        <div class="field field-inline">
+          <label for="background_image_position">Image position</label>
+          <input id="background_image_position" data-field="background_image_position" type="text" value="${this._config.background_image_position || 'center'}" placeholder="center">
+        </div>
+      </div>
+      <div class="field field-inline">
+        <label for="background_image_repeat">Image repeat</label>
+        <input id="background_image_repeat" data-field="background_image_repeat" type="text" value="${this._config.background_image_repeat || 'no-repeat'}" placeholder="no-repeat">
+      </div>
+    `);
+
+    const eventSection = this.renderSection('Events & schedule', `
+      <div class="field-row">
+        <div class="field">
+          <label for="max_events">Max events (0 = unlimited)</label>
+          <input id="max_events" data-field="max_events" data-type="number" type="number" min="0" value="${Number(this._config.max_events ?? this._config.maxEvents ?? this.getEditorDefaultValue('max_events'))}">
+        </div>
+        <div class="field">
+          <label for="event_font_size">Event font size</label>
+          <input id="event_font_size" data-field="event_font_size" data-type="number" type="number" min="8" max="32" value="${Number(this._config.event_font_size ?? this.getEditorDefaultValue('event_font_size'))}">
+        </div>
+      </div>
+      ${this.renderSubSection('Hide times for calendars', `<div class="list-checkbox-grid">${this.renderCalendarListCheckboxes('hide_times_for_calendars', { label: 'hidden times calendars' })}</div>`)}
+      <div class="boolean-list">
+        <label><input type="checkbox" data-field="show_current_time_bar" ${this._config.show_current_time_bar ? 'checked' : ''}> Show current time bar</label>
+        <label><input type="checkbox" data-field="use_24hr_schedule" ${this._config.use_24hr_schedule ? 'checked' : ''}> Use 24-hour schedule time</label>
+        <label><input type="checkbox" data-field="hide_event_calendar_bubble" ${this._config.hide_event_calendar_bubble ? 'checked' : ''}> Hide event calendar bubble</label>
+        <label><input type="checkbox" data-field="combine_calendars" ${this._config.combine_calendars ? 'checked' : ''}> Combine duplicate events across calendars</label>
+      </div>
+      <div class="field">
+        <label for="combine_calendars_width">Combined stripe width (px)</label>
+        <input id="combine_calendars_width" data-field="combine_calendars_width" data-type="number" type="number" min="1" value="${Number(this._config.combine_calendars_width ?? this.getEditorDefaultValue('combine_calendars_width'))}">
+      </div>
+    `);
+
+    const managementSection = this.renderSection('Event management', `
+      <div class="boolean-list">
+        <label><input type="checkbox" data-field="enable_event_management" ${this._config.enable_event_management !== false ? 'checked' : ''}> Enable event management</label>
+      </div>
+      ${this.renderSubSection('Read-only calendars', `<div class="list-checkbox-grid">${this.renderCalendarListCheckboxes('readonly_calendars', { label: 'read-only calendars' })}</div>`)}
+    `);
+
+    const localeSection = this.renderSection('Localization & preferences', `
+      <div class="field-row">
+        <div class="field field-inline">
+          <label for="language">Language code</label>
+          <input id="language" data-field="language" type="text" value="${this._config.language || ''}" placeholder="en, fr, de...">
+        </div>
+        <div class="field field-inline">
+          <label for="locale">Locale override</label>
+          <input id="locale" data-field="locale" type="text" value="${this._config.locale || ''}" placeholder="en-US">
+        </div>
+      </div>
+      <div class="field field-inline">
+        <label for="preference_storage_key">Preference storage key</label>
+        <input id="preference_storage_key" data-field="preference_storage_key" type="text" value="${this._config.preference_storage_key || ''}" placeholder="Optional custom key">
+      </div>
+    `);
 
     this.innerHTML = `
       <style>
@@ -6139,19 +6635,306 @@ class SkylightCalendarCardEditor extends HTMLElement {
           gap: 4px;
         }
 
+        .field.field-inline {
+          display: grid;
+          grid-template-columns: minmax(180px, 260px) 1fr;
+          align-items: center;
+          gap: 8px;
+        }
+
+        .field-row {
+          display: grid;
+          gap: 8px;
+          grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        }
+
         .field label {
           font-weight: 500;
           color: var(--primary-text-color);
         }
 
         .field input,
-        .field select {
+        .field select,
+        .field textarea {
           padding: 8px;
           border: 1px solid var(--divider-color);
           border-radius: 6px;
           font: inherit;
           color: var(--primary-text-color);
           background: var(--card-background-color);
+        }
+
+        .field textarea {
+          min-height: 70px;
+          resize: vertical;
+        }
+
+        .weekday-grid {
+          display: grid;
+          grid-template-columns: repeat(7, minmax(0, 1fr));
+          gap: 6px;
+          align-items: center;
+          border: 1px solid var(--divider-color);
+          border-radius: 6px;
+          padding: 8px;
+          background: var(--card-background-color);
+        }
+
+        .weekday-label {
+          text-align: center;
+          font-weight: 500;
+          color: var(--secondary-text-color);
+          font-size: 0.85rem;
+        }
+
+        .weekday-checkbox-wrap {
+          display: flex;
+          justify-content: center;
+        }
+
+        .map-grid {
+          display: grid;
+          gap: 8px;
+        }
+
+        .map-row {
+          display: grid;
+          grid-template-columns: minmax(160px, 220px) 1fr;
+          gap: 8px;
+          align-items: center;
+        }
+
+        .list-checkbox-grid {
+          display: grid;
+          gap: 8px;
+        }
+
+        .list-checkbox-row {
+          display: grid;
+          grid-template-columns: minmax(160px, 220px) 1fr;
+          gap: 8px;
+          align-items: center;
+          font-weight: 400;
+        }
+
+        .list-checkbox-row input[type="checkbox"] {
+          justify-self: end;
+        }
+
+        .color-picker-wrap {
+          display: inline-flex;
+          align-items: center;
+        }
+
+        .selected-color-swatch {
+          width: 26px;
+          height: 26px;
+          border-radius: 6px;
+          border: 1px solid var(--divider-color);
+          background: var(--selected-color);
+          cursor: pointer;
+          padding: 0;
+          display: inline-block;
+        }
+
+        .color-picker-dialog {
+          display: none;
+          position: fixed;
+          inset: 0;
+          z-index: 1000;
+        }
+
+        .color-picker-dialog.show {
+          display: block;
+        }
+
+        .color-picker-overlay {
+          position: absolute;
+          inset: 0;
+          background: rgba(0, 0, 0, 0.4);
+        }
+
+        .color-picker-modal {
+          position: absolute;
+          left: 50%;
+          top: 50%;
+          transform: translate(-50%, -50%);
+          width: min(460px, calc(100vw - 24px));
+          background: var(--card-background-color);
+          border-radius: 12px;
+          padding: 16px;
+          box-shadow: 0 8px 26px rgba(0, 0, 0, 0.25);
+          display: grid;
+          gap: 12px;
+        }
+
+        .color-picker-title {
+          font-size: 1.8rem;
+          font-weight: 600;
+        }
+
+        .color-picker-wheel {
+          position: relative;
+          width: 260px;
+          height: 260px;
+          border-radius: 50%;
+          margin: 0 auto;
+          background:
+            radial-gradient(circle at center, #ffffff 0%, rgba(255, 255, 255, 0.85) 16%, rgba(255, 255, 255, 0) 58%),
+            conic-gradient(from 0deg, #ff0000, #ff7f00, #ffff00, #00ff00, #00ffff, #0000ff, #8b00ff, #ff00ff, #ff0000);
+        }
+
+        .color-picker-wheel-marker {
+          position: absolute;
+          width: 16px;
+          height: 16px;
+          border-radius: 50%;
+          border: 2px solid white;
+          box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5);
+          transform: translate(-50%, -50%);
+          pointer-events: none;
+        }
+
+        .color-picker-controls {
+          display: grid;
+          gap: 6px;
+        }
+
+        .color-picker-controls input[type="text"] {
+          padding: 8px;
+          border: 1px solid var(--divider-color);
+          border-radius: 6px;
+          font: inherit;
+          color: var(--primary-text-color);
+          background: var(--card-background-color);
+        }
+
+        .color-picker-presets {
+          display: grid;
+          grid-template-columns: repeat(4, minmax(0, 1fr));
+          gap: 10px;
+        }
+
+        .color-preset {
+          width: 100%;
+          aspect-ratio: 1;
+          border-radius: 50%;
+          border: 2px solid rgba(0, 0, 0, 0.08);
+          cursor: pointer;
+        }
+
+        .color-picker-selected-row {
+          display: flex;
+          align-items: center;
+          gap: 10px;
+        }
+
+        .color-picker-preview {
+          width: 24px;
+          height: 24px;
+          border-radius: 4px;
+          border: 1px solid var(--divider-color);
+        }
+
+        .color-picker-value {
+          font-family: monospace;
+        }
+
+        .color-picker-actions {
+          display: flex;
+          justify-content: flex-end;
+          gap: 10px;
+        }
+
+        .color-picker-actions button {
+          border: 1px solid var(--divider-color);
+          background: var(--card-background-color);
+          border-radius: 6px;
+          padding: 8px 12px;
+          cursor: pointer;
+          color: var(--primary-text-color);
+        }
+
+        .color-picker-actions button.primary {
+          background: var(--primary-color);
+          color: white;
+          border-color: transparent;
+        }
+
+        .map-label {
+          font-weight: 500;
+          color: var(--primary-text-color);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .config-section {
+          border: 1px solid var(--divider-color);
+          border-radius: 6px;
+          background: color-mix(in srgb, var(--card-background-color) 96%, var(--primary-text-color) 4%);
+        }
+
+        .config-section summary {
+          cursor: pointer;
+          padding: 10px;
+          font-weight: 600;
+          list-style: none;
+          display: flex;
+          align-items: center;
+          gap: 8px;
+        }
+
+        .config-section summary::before,
+        .config-subsection summary::before {
+          content: '›';
+          font-size: 1.2rem;
+          line-height: 1;
+          transform: rotate(0deg);
+          transition: transform 120ms ease;
+          color: var(--secondary-text-color);
+        }
+
+        .config-section[open] > summary::before,
+        .config-subsection[open] > summary::before {
+          transform: rotate(90deg);
+        }
+
+        .config-section summary::-webkit-details-marker {
+          display: none;
+        }
+
+        .section-content {
+          border-top: 1px solid var(--divider-color);
+          padding: 10px;
+          display: flex;
+          flex-direction: column;
+          gap: 10px;
+        }
+
+        .config-subsection {
+          border: 1px solid var(--divider-color);
+          border-radius: 6px;
+          background: var(--card-background-color);
+        }
+
+        .config-subsection summary {
+          cursor: pointer;
+          padding: 8px 10px;
+          font-weight: 600;
+          list-style: none;
+          display: flex;
+          align-items: center;
+          gap: 8px;
+        }
+
+        .config-subsection summary::-webkit-details-marker {
+          display: none;
+        }
+
+        .subsection-content {
+          border-top: 1px solid var(--divider-color);
+          padding: 10px;
         }
 
         .entity-list,
@@ -6184,7 +6967,7 @@ class SkylightCalendarCardEditor extends HTMLElement {
         }
       </style>
       <div class="card-config">
-        <div class="field">
+        <div class="field field-inline">
           <label for="title">Title</label>
           <input id="title" data-field="title" type="text" value="${this._config.title || ''}" placeholder="Family Calendar">
         </div>
@@ -6192,9 +6975,9 @@ class SkylightCalendarCardEditor extends HTMLElement {
         <div class="field">
           <label for="default_view">Default view</label>
           <select id="default_view" data-field="default_view">
-            <option value="month" ${this._config.default_view === 'month' ? 'selected' : ''}>Month</option>
-            <option value="week-compact" ${this._config.default_view === 'week-compact' ? 'selected' : ''}>Week</option>
-            <option value="week-standard" ${this._config.default_view === 'week-standard' ? 'selected' : ''}>Schedule</option>
+            <option value="month" ${this.normalizeDefaultViewForEditor(this._config.default_view) === 'month' ? 'selected' : ''}>Month</option>
+            <option value="week-compact" ${this.normalizeDefaultViewForEditor(this._config.default_view) === 'week-compact' ? 'selected' : ''}>Week</option>
+            <option value="week-standard" ${this.normalizeDefaultViewForEditor(this._config.default_view) === 'week-standard' ? 'selected' : ''}>Schedule</option>
           </select>
         </div>
 
@@ -6204,13 +6987,14 @@ class SkylightCalendarCardEditor extends HTMLElement {
           <p class="helper">Select one or more calendar entities to display.</p>
         </div>
 
-        <div class="field">
-          <label>Boolean options</label>
-          <div class="boolean-list">
-            ${boolOptionsMarkup}
-          </div>
-        </div>
+        ${displayLayoutSection}
+        ${colorStylingSection}
+        ${backgroundSection}
+        ${eventSection}
+        ${managementSection}
+        ${localeSection}
       </div>
+      ${this.renderColorPickerDialog()}
     `;
 
     this.refreshCalendarEntities();
@@ -6219,6 +7003,84 @@ class SkylightCalendarCardEditor extends HTMLElement {
       const eventName = input.type === 'text' ? 'input' : 'change';
       input.addEventListener(eventName, (event) => this.handleChange(event));
     });
+
+    this.querySelectorAll('[data-map-field]').forEach((input) => {
+      input.addEventListener('change', (event) => this.handleChange(event));
+    });
+
+    this.querySelectorAll('[data-list-field]').forEach((input) => {
+      input.addEventListener('change', (event) => this.handleChange(event));
+    });
+
+    this.querySelectorAll('[data-weekday]').forEach((input) => {
+      input.addEventListener('change', (event) => this.handleChange(event));
+    });
+
+    this.querySelectorAll('[data-color-trigger]').forEach((trigger) => {
+      trigger.addEventListener('click', () => this.openColorPicker(trigger.dataset.colorField, trigger.dataset.colorMapKey || null));
+    });
+
+    const wheel = this.querySelector('#color-picker-wheel');
+    if (wheel) {
+      let dragging = false;
+      wheel.addEventListener('pointerdown', (event) => {
+        dragging = true;
+        this.updateColorPickerFromWheelEvent(event);
+      });
+      wheel.addEventListener('pointermove', (event) => {
+        if (dragging) this.updateColorPickerFromWheelEvent(event);
+      });
+      wheel.addEventListener('pointerup', () => { dragging = false; });
+      wheel.addEventListener('pointerleave', () => { dragging = false; });
+    }
+
+    this.querySelectorAll('[data-color-preset]').forEach((preset) => {
+      preset.addEventListener('click', () => {
+        const hex = preset.dataset.colorPreset;
+        const hsv = this.hexToHsv(hex);
+        this._colorPickerState.h = hsv.h;
+        this._colorPickerState.s = hsv.s;
+        this._colorPickerState.v = hsv.v;
+        this._colorPickerState.color = this.hsvToHex(hsv.h, hsv.s, hsv.v);
+        this.syncColorPickerUi();
+      });
+    });
+
+    this.querySelectorAll('[data-close-color-picker]').forEach((button) => {
+      button.addEventListener('click', () => this.closeColorPicker());
+    });
+
+    const brightnessInput = this.querySelector('#color-picker-brightness');
+    if (brightnessInput) {
+      brightnessInput.addEventListener('input', (event) => {
+        this._colorPickerState.v = Number(event.target.value) / 100;
+        this._colorPickerState.color = this.hsvToHex(this._colorPickerState.h, this._colorPickerState.s, this._colorPickerState.v);
+        this.syncColorPickerUi();
+      });
+    }
+
+    const hexInput = this.querySelector('#color-picker-hex');
+    if (hexInput) {
+      const syncHexColor = () => {
+        const normalizedHex = this.normalizeHexColorInput(hexInput.value);
+        if (!normalizedHex) return;
+        const hsv = this.hexToHsv(normalizedHex);
+        this._colorPickerState.h = hsv.h;
+        this._colorPickerState.s = hsv.s;
+        this._colorPickerState.v = hsv.v;
+        this._colorPickerState.color = normalizedHex;
+        this.syncColorPickerUi();
+      };
+      hexInput.addEventListener('input', syncHexColor);
+      hexInput.addEventListener('change', syncHexColor);
+    }
+
+    const applyBtn = this.querySelector('#apply-color-picker');
+    if (applyBtn) {
+      applyBtn.addEventListener('click', () => {
+        this.applyColorPickerColor(this._colorPickerState.color);
+      });
+    }
 
     this._rendered = true;
   }
@@ -6267,14 +7129,74 @@ class SkylightCalendarCardEditor extends HTMLElement {
 
     const defaultView = this.querySelector('select[data-field="default_view"]');
     if (defaultView && document.activeElement !== defaultView) {
-      defaultView.value = this._config.default_view || 'month';
+      defaultView.value = this.normalizeDefaultViewForEditor(this._config.default_view);
     }
 
-    this.querySelectorAll('.boolean-list input[type="checkbox"][data-field]').forEach((checkbox) => {
+    const firstDayOfWeek = this.querySelector('select[data-field="first_day_of_week"]');
+    if (firstDayOfWeek && document.activeElement !== firstDayOfWeek) {
+      firstDayOfWeek.value = String(Number(this._config.first_day_of_week ?? 0));
+    }
+
+    this.querySelectorAll('input[type="checkbox"][data-field]').forEach((checkbox) => {
+      if (checkbox.dataset.field === 'enable_event_management') {
+        checkbox.checked = this._config.enable_event_management !== false;
+        return;
+      }
       checkbox.checked = !!this._config[checkbox.dataset.field];
     });
 
+    this.querySelectorAll('input[type="checkbox"][data-list-field]').forEach((checkbox) => {
+      const listField = checkbox.dataset.listField;
+      checkbox.checked = this.getListFieldValue(listField).includes(checkbox.value);
+    });
+
+    this.querySelectorAll('input[data-type="number"], input[data-type="nullable-number"], input[data-type="list"], input[data-field="language"], input[data-field="locale"], input[data-field="preference_storage_key"], input[data-field="background_image_url"], input[data-field="background_image_size"], input[data-field="background_image_position"], input[data-field="background_image_repeat"]').forEach((input) => {
+      if (document.activeElement === input) return;
+      const field = input.dataset.field;
+      const type = input.dataset.type;
+      if (type === 'list') input.value = this.getListInputValue(field);
+      else if (type === 'nullable-number') input.value = this._config[field] ?? '';
+      else if (type === 'number') input.value = Number(this._config[field] ?? this.getEditorDefaultValue(field));
+      else input.value = this._config[field] || '';
+    });
+
+    this.querySelectorAll('input[type="checkbox"][data-weekday]').forEach((checkbox) => {
+      const weekday = Number(checkbox.dataset.weekday);
+      checkbox.checked = this.getListFieldValue('week_days').includes(weekday);
+    });
+
+    const headerColorTextInput = this.querySelector('input[data-field="header_color_text"]');
+    if (headerColorTextInput && document.activeElement !== headerColorTextInput) {
+      headerColorTextInput.value = this._config.header_color || '';
+    }
+
+    this.querySelectorAll('[data-map-field]').forEach((input) => {
+      if (document.activeElement === input) return;
+      const mapField = input.dataset.mapField;
+      const mapKey = input.dataset.mapKey;
+      const value = this.getMapFieldValue(mapField)[mapKey] || '';
+      input.value = value;
+    });
+
+    this.querySelectorAll('.selected-color-swatch').forEach((swatch) => {
+      const field = swatch.dataset.colorField;
+      const mapKey = swatch.dataset.colorMapKey || null;
+      const nextColor = this.getColorValue(field, mapKey);
+      swatch.style.setProperty('--selected-color', nextColor);
+    });
+
     this.refreshCalendarEntities();
+  }
+
+  parseList(value, { asNumbers = false } = {}) {
+    const parsed = String(value || '')
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+    if (!asNumbers) return parsed;
+    return parsed
+      .map((item) => Number(item))
+      .filter((item) => Number.isFinite(item));
   }
 
   handleChange(event) {
@@ -6284,8 +7206,68 @@ class SkylightCalendarCardEditor extends HTMLElement {
     if (field === 'entity') {
       const selected = Array.from(this.querySelectorAll('input[data-field="entity"]:checked')).map((input) => input.value);
       nextConfig.entities = selected;
+      this._config = nextConfig;
+      this.render();
+      this.dispatchEvent(
+        new CustomEvent('config-changed', {
+          detail: { config: nextConfig },
+          bubbles: true,
+          composed: true
+        })
+      );
+      return;
+    } else if (event.target.dataset.mapField) {
+      const mapField = event.target.dataset.mapField;
+      const mapKey = event.target.dataset.mapKey;
+      const mapValue = { ...this.getMapFieldValue(mapField) };
+      const nextValue = event.target.value;
+      if (nextValue === '') delete mapValue[mapKey];
+      else mapValue[mapKey] = nextValue;
+      nextConfig[mapField] = mapValue;
+    } else if (event.target.dataset.listField) {
+      const listField = event.target.dataset.listField;
+      const checkedValues = Array.from(this.querySelectorAll(`input[data-list-field="${listField}"]:checked`)).map((input) => input.value);
+      nextConfig[listField] = checkedValues;
+    } else if (event.target.dataset.weekday !== undefined) {
+      const selectedWeekdays = Array.from(this.querySelectorAll('input[data-weekday]:checked'))
+        .map((input) => Number(input.dataset.weekday))
+        .filter((value) => Number.isFinite(value))
+        .sort((a, b) => a - b);
+      nextConfig.week_days = selectedWeekdays;
     } else if (event.target.type === 'checkbox') {
       nextConfig[field] = event.target.checked;
+      if (field === 'compact_height') {
+        this._config = nextConfig;
+        this.render();
+        this.dispatchEvent(
+          new CustomEvent('config-changed', {
+            detail: { config: nextConfig },
+            bubbles: true,
+            composed: true
+          })
+        );
+        return;
+      }
+    } else if (event.target.dataset.type === 'color') {
+      nextConfig[field] = event.target.value;
+    } else if (event.target.dataset.type === 'color-text') {
+      nextConfig.header_color = event.target.value;
+    } else if (event.target.dataset.type === 'number') {
+      if (event.target.value === '') {
+        nextConfig[field] = this.getEditorDefaultValue(field);
+      } else {
+        const numericValue = Number(event.target.value);
+        nextConfig[field] = Number.isFinite(numericValue) ? numericValue : this.getEditorDefaultValue(field);
+      }
+    } else if (event.target.dataset.type === 'nullable-number') {
+      if (event.target.value === '') {
+        nextConfig[field] = null;
+      } else {
+        const numericValue = Number(event.target.value);
+        nextConfig[field] = Number.isFinite(numericValue) ? numericValue : null;
+      }
+    } else if (event.target.dataset.type === 'list') {
+      nextConfig[field] = this.parseList(event.target.value);
     } else {
       nextConfig[field] = event.target.value;
     }


### PR DESCRIPTION
### Motivation

- Improve the card editor UX by providing structured sections, calendar-specific mappings (colors, names, icons), and inline controls for common configuration tasks.
- Add a built-in color picker to make it easier to choose and apply hex colors for headers, calendars and event fonts.
- Make editor updates more robust by normalizing view values, sanitizing inputs, and avoiding unnecessary re-renders when calendar entities haven't changed.

### Description

- Implement a new, stateful color picker (`_colorPickerState`) with HSV/HEX conversion utilities (`hexToHsv`, `hsvToHex`) and a modal color-picker UI including wheel, brightness, presets, and preview, plus event handlers to open/close/apply colors.
- Restructure the editor render into modular sections (`renderSection`, `renderSubSection`) and add many new helper methods for working with maps and lists (`getMapFieldValue`, `getListFieldValue`, `getListInputValue`, `parseList`) and to normalize values (`normalizeDefaultViewForEditor`, `normalizeHexColorInput`, `toColorInputValue`).
- Add support for calendar-scoped mappings and controls: `renderMapRowInputs` for per-calendar inputs (colors, names, icons), `renderCalendarListCheckboxes` for list fields, weekday checkboxes, color swatches, and richer form controls with improved styling and layout CSS.
- Extend `setConfig`, `updateFieldValues`, `handleChange`, and `refreshCalendarEntities` to handle entities lists, map/list fields, nullable/typed number inputs, weekday selection, color triggers, and conditional re-renders when entities or layout options change; and emit `config-changed` events on updates.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab59b0b9ac83318cb31211bfa1a9ae)