### PR TITLE
Add configurable combine style and background for merged calendar events

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3577,10 +3577,14 @@ class SkylightCalendarCard extends HTMLElement {
       : [event.entityId];
 
     const preferredEntityId = visibleEntityIds[0] || event.entityId;
-    if (!preferredEntityId) return 'white';
+    const configuredColor = preferredEntityId
+      ? this.normalizeSingleColor(this._config?.event_font_colors?.[preferredEntityId])
+      : null;
+    if (configuredColor) {
+      return configuredColor;
+    }
 
-    const configuredColor = this.normalizeSingleColor(this._config?.event_font_colors?.[preferredEntityId]);
-    return configuredColor || 'white';
+    return this.getContractColor(this.getEventBackgroundColor(event));
   }
 
   shouldShowEventTime(event) {
@@ -3969,6 +3973,25 @@ class SkylightCalendarCard extends HTMLElement {
     if (option === 'primary') return primaryColor;
     if (option === 'neutral') return '#F8F3E9';
     return option;
+  }
+
+  getEventBackgroundColor(event) {
+    const visibleColors = this.getVisibleCalendarColorsForEvent(event);
+    const primaryColor = visibleColors[0] || event?.color || '#3b82f6';
+
+    if (visibleColors.length <= 1) {
+      return primaryColor;
+    }
+
+    return this.getCombinedBackgroundColor(visibleColors, primaryColor);
+  }
+
+  getContractColor(backgroundColor) {
+    const rgb = this.colorToRgb(backgroundColor);
+    if (!rgb) return 'white';
+
+    const luminance = (0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b) / 255;
+    return luminance > 0.6 ? 'black' : 'white';
   }
 
   getIndicatorColors(visibleColors, combineStyle, combineBackgroundOption) {


### PR DESCRIPTION
### Motivation

- Provide more flexible visuals for combined/merged calendar events by introducing selectable indicator styles and background options. 
- Ensure combined-event indicators don't overlap event text by adding a left offset variable and updating paddings across views. 

### Description

- Introduce new config options `combine_style` and `combine_background` with normalization helpers (`normalizeCombineStyle`, `normalizeCombineBackground`) and add them to the stub config and editor UI. 
- Implement three visual treatments: zebra `stripes` (existing behavior), vertical `bars`, and `dots`, with new helper functions `createVerticalBarsGradient`, `createDotsDecoration`, `getCombinedBackgroundColor`, and `getIndicatorColors`. 
- Adjust `getEventStyle` to branch on `combine_style` and return CSS that sets `--combine-left-offset` and appropriate `background-image`/`background-color` based on the chosen style and `combine_background`. 
- Update CSS paddings in event-related selectors to use `calc(... + var(--combine-left-offset, 0px))` and increase default `combine_calendars_width` from `12` to `18` in config/editor defaults. 
- Update editor form handling to include `combine_background` input and `combine_style` select, and ensure input/select initialization covers the new fields. 

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e7405d00833185220f94e67f6e0a)