### PR TITLE
Exclude description from calendar-combine matching and show match criteria in editor

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3867,10 +3867,10 @@ class SkylightCalendarCard extends HTMLElement {
     const start = this.getNormalizedEventTimeValue(event.start);
     const end = this.getNormalizedEventTimeValue(event.end);
     const summary = this.normalizeEventTextValue(event.summary);
-    const description = this.normalizeEventTextValue(event.description);
     const location = this.normalizeEventTextValue(event.location);
-    return `${start}|${end}|${summary}|${description}|${location}`;
+    return `${start}|${end}|${summary}|${location}`;
   }
+
 
   combineDuplicateCalendarEvents(events) {
     if (!this._config.combine_calendars) {
@@ -6797,6 +6797,7 @@ class SkylightCalendarCardEditor extends HTMLElement {
         <label><input type="checkbox" data-field="hide_event_calendar_bubble" ${this._config.hide_event_calendar_bubble ? 'checked' : ''}> Hide event calendar bubble</label>
         <label><input type="checkbox" data-field="combine_calendars" ${this._config.combine_calendars ? 'checked' : ''}> Combine duplicate events across calendars</label>
       </div>
+      <div class="field-note">Match criteria for combining calendars: Start, End, Title, Location</div>
       <div class="field">
         <label for="combine_style">Combined indicator style</label>
         <select id="combine_style" data-field="combine_style">


### PR DESCRIPTION
### Motivation
- Prevent events from being considered different solely because their descriptions differ when `combine_calendars: true`, and make the editor explicitly show which fields are used for matching.

### Description
- Removed `description` from the duplicate-event match key so events are matched on `Start`, `End`, `Title`, and `Location` only by changing `getEventExactMatchKey`.
- Added a static note in the card editor UI that displays the match criteria: `Start, End, Title, Location`.

### Testing
- Ran a syntax check with `node --check skylight-calendar-card.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1fc7a40d4833198b4dbc91b4cfef0)