### PR TITLE
Robust ISO date/time parsing for event start/end values

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3845,8 +3845,36 @@ class SkylightCalendarCard extends HTMLElement {
   getNormalizedEventTimeValue(value) {
     if (!value) return '';
 
+    const toDateTimeTimestamp = (rawValue) => {
+      const normalizedRaw = this.normalizeEventTextValue(rawValue);
+      if (!normalizedRaw) return null;
+
+      const floatingMatch = normalizedRaw.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})?$/i);
+      if (!floatingMatch) {
+        return null;
+      }
+
+      const [, yearText, monthText, dayText, hourText, minuteText, secondText, fractionText, tzText] = floatingMatch;
+      const year = Number(yearText);
+      const month = Number(monthText);
+      const day = Number(dayText);
+      const hour = Number(hourText);
+      const minute = Number(minuteText);
+      const second = Number(secondText || '0');
+      const millis = Number(((fractionText || '').slice(0, 3)).padEnd(3, '0'));
+
+      const timestamp = tzText
+        ? Date.parse(`${yearText}-${monthText}-${dayText}T${hourText}:${minuteText}:${String(second).padStart(2, '0')}.${String(millis).padStart(3, '0')}${tzText.toUpperCase()}`)
+        : new Date(year, month - 1, day, hour, minute, second, millis).getTime();
+
+      return Number.isFinite(timestamp) ? timestamp : null;
+    };
+
     if (typeof value === 'object') {
       if (value.dateTime) {
+        const parsedTimestamp = toDateTimeTimestamp(value.dateTime);
+        if (parsedTimestamp !== null) return `dt:${parsedTimestamp}`;
+
         const ts = new Date(value.dateTime).getTime();
         return Number.isFinite(ts) ? `dt:${ts}` : `dt:${String(value.dateTime)}`;
       }
@@ -3863,6 +3891,9 @@ class SkylightCalendarCard extends HTMLElement {
     if (/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
       return `d:${normalized}`;
     }
+
+    const parsedTimestamp = toDateTimeTimestamp(normalized);
+    if (parsedTimestamp !== null) return `dt:${parsedTimestamp}`;
 
     const ts = new Date(normalized).getTime();
     return Number.isFinite(ts) ? `dt:${ts}` : normalized;


### PR DESCRIPTION
### Motivation

- Improve robustness and consistency when parsing event start/end times so ISO-like strings with timezone offsets, fractional seconds, or local datetimes are handled reliably across environments.

### Description

- Add an internal `toDateTimeTimestamp` helper inside `getNormalizedEventTimeValue` to normalize input and extract date/time components via regex and produce millisecond timestamps.  
- Use `toDateTimeTimestamp` to parse `value.dateTime` objects and normalized string values and return `dt:<timestamp>` when a timestamp can be derived.  
- Preserve existing fallback behavior by falling back to `new Date(...)` or returning the original string when parsing fails.  
- Implement changes in `skylight-calendar-card.js` and ensure normalized whitespace and Unicode normalization are applied before parsing.

### Testing

- Ran unit tests with `npm test`, and they all passed.  
- Ran linter with `npm run lint`, and no lint errors were reported.  
- Verified the project build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b23b8863708331a309f198c9da430f)