### PR TITLE
Add GitHub Action to attach skylight-calendar-card.js to releases

### DIFF
--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -1,0 +1,20 @@
+name: Upload release asset
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  upload-asset:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Upload skylight-calendar-card.js to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: skylight-calendar-card.js


### PR DESCRIPTION
### Motivation
- Automatically attach the built JavaScript `skylight-calendar-card.js` to every published GitHub release so users can download the single-file asset.

### Description
- Add `.github/workflows/upload-release-asset.yml` which triggers on `release.published`, grants `contents: write`, checks out the repository, and uses `softprops/action-gh-release@v2` to upload `skylight-calendar-card.js` as a release asset.

### Testing
- Ran `git diff --check`, `git status --short`, and inspected `sed -n '1,200p' .github/workflows/upload-release-asset.yml`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b35959237c8331936cc0a953a40d74)