### PR TITLE
Use Intl formatting for period labels and widen `.month-year` header

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1566,11 +1566,6 @@ class SkylightCalendarCard extends HTMLElement {
         margin-left: auto;
       }
 
-      .period-controls .month-year,
-      .compact-period-controls .month-year {
-        min-width: auto;
-      }
-
       .header-controls.is-wrapped {
         justify-content: center;
       }
@@ -1671,7 +1666,7 @@ class SkylightCalendarCard extends HTMLElement {
         font-size: 18px;
         font-weight: 500;
         color: white;
-        min-width: 140px;
+        min-width: 210px;
         text-align: center;
       }
       
@@ -2963,9 +2958,6 @@ class SkylightCalendarCard extends HTMLElement {
           text-align: center;
         }
         
-        .month-year {
-          min-width: auto;
-        }
         
         .week-standard-container {
           font-size: 10px;
@@ -3137,35 +3129,39 @@ class SkylightCalendarCard extends HTMLElement {
         const totalWeeks = this._config.rolling_weeks + 1;
         const weekEnd = new Date(weekStart);
         weekEnd.setDate(weekStart.getDate() + (totalWeeks * 7) - 1);
-        
-        if (weekStart.getMonth() === weekEnd.getMonth() && weekStart.getFullYear() === weekEnd.getFullYear()) {
-          return `${this.getMonthNameShort(weekStart.getMonth())} ${weekStart.getDate()}-${weekEnd.getDate()}, ${weekStart.getFullYear()}`;
-        } else if (weekStart.getFullYear() === weekEnd.getFullYear()) {
-          return `${this.getMonthNameShort(weekStart.getMonth())} ${weekStart.getDate()} - ${this.getMonthNameShort(weekEnd.getMonth())} ${weekEnd.getDate()}, ${weekStart.getFullYear()}`;
-        } else {
-          return `${this.getMonthNameShort(weekStart.getMonth())} ${weekStart.getDate()}, ${weekStart.getFullYear()} - ${this.getMonthNameShort(weekEnd.getMonth())} ${weekEnd.getDate()}, ${weekEnd.getFullYear()}`;
-        }
+
+        return this.formatPeriodDateRange(weekStart, weekEnd);
       }
       
       // Standard month view
       const month = this._currentDate.getMonth();
       const year = this._currentDate.getFullYear();
-      return `${this.getMonthNameShort(month)} ${year}`;
+      return `${this.getMonthName(month)} ${year}`;
     } else {
       const weekDays = this.getWeekDays();
       if (weekDays.length === 0) return '';
       const start = weekDays[0];
       const end = weekDays[weekDays.length - 1];
-      if (start.getMonth() === end.getMonth()) {
-        if (start.getDate() === end.getDate()) {
-          return `${this.getMonthNameShort(start.getMonth())} ${start.getDate()}, ${start.getFullYear()}`;
-        } else {
-          return `${this.getMonthNameShort(start.getMonth())} ${start.getDate()}-${end.getDate()}, ${start.getFullYear()}`;
-        }
-      } else {
-        return `${this.getMonthNameShort(start.getMonth())} ${start.getDate()} - ${this.getMonthNameShort(end.getMonth())} ${end.getDate()}, ${start.getFullYear()}`;
-      }
+      return this.formatPeriodDateRange(start, end);
     }
+  }
+
+  formatPeriodDateRange(startDate, endDate) {
+    const formatter = new Intl.DateTimeFormat(this.getLocale(), {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    });
+
+    if (typeof formatter.formatRange === 'function') {
+      return formatter.formatRange(startDate, endDate);
+    }
+
+    if (startDate.getTime() === endDate.getTime()) {
+      return formatter.format(startDate);
+    }
+
+    return `${formatter.format(startDate)} - ${formatter.format(endDate)}`;
   }
 
   renderCalendarView() {


### PR DESCRIPTION
### Motivation

- Improve and unify how period labels are rendered so date ranges are localized and more readable across views.
- Prevent the month/year header from truncating by increasing its available width.
- Remove duplicated/unused CSS rules to simplify styling.

### Description

- Replaced manual string assembly in `getPeriodLabel()` for rolling weeks and week ranges with a new helper `formatPeriodDateRange(startDate, endDate)` that uses `Intl.DateTimeFormat` and `formatRange` when available to produce localized date ranges and handles single-day ranges.
- Switched the month view label to use `getMonthName()` instead of `getMonthNameShort()` to render the month label more clearly.
- Increased the `.month-year` CSS `min-width` from `140px` to `210px` and removed redundant `.period-controls .month-year` rules to simplify layout behavior.

### Testing

- Ran lint via `npm run lint` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4bf32105483318d7d981bbf487f3e)