### PR TITLE
Show event locations and optional friendly calendar names in week views

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1895,9 +1895,9 @@ class SkylightCalendarCard extends HTMLElement {
         opacity: 0.9;
         margin-top: 4px;
         line-height: 1.3;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        overflow-wrap: anywhere;
+        word-break: break-word;
       }
       
       /* Week Standard View Styles */
@@ -2238,9 +2238,9 @@ class SkylightCalendarCard extends HTMLElement {
         opacity: 0.9;
         margin-top: 4px;
         line-height: 1.3;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: normal;
+        overflow-wrap: anywhere;
+        word-break: break-word;
       }
 
       .week-standard-event-calendar-name {


### PR DESCRIPTION
### Motivation
- Add the ability to display event `location` in compact and standard week views and the day compact modal.
- Provide a configurable font size for event location text and a new option to show the friendly calendar name instead of the calendar icon in event bubbles.
- Expose editor controls so card authors can enable/disable these behaviors and choose the calendar-bubble display mode.

### Description
- Added new config options `show_event_location`, `event_location_font_size`, and `event_calendar_friendly_name` and updated `getStubConfig()` defaults.
- Implemented rendering changes in `renderWeekCompact`, `renderWeekStandard`, and `showDayCompactModal` to include a `.week-*-event-location` element when `shouldShowEventLocation()` is true, and wired `--event-location-font-size` into event styles.
- Added CSS rules for `.week-compact-event-location`, `.week-standard-event-location`, and `.week-standard-event-calendar-name`, and new helper methods `getEventLocationFontSize()` and `shouldShowEventLocation()`.
- Updated `renderEventIcon()` to support the new friendly-name mode, and extended the editor UI with an `event_calendar_bubble_mode` select and `event_location_font_size` input plus handling in `getEventCalendarBubbleMode()` and `handleChange()` to map the selected mode to config flags.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b638c956748331971f023d9027250f)