### PR TITLE
Respect schedule time-slot when opening Create Event dialog

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4440,7 +4440,7 @@ class SkylightCalendarCard extends HTMLElement {
         // Set the time on the date
         date.setHours(hour, 0, 0, 0);
         
-        this.showCreateEventModal(date);
+        this.showCreateEventModal(date, date);
       });
     });
     
@@ -4639,11 +4639,12 @@ class SkylightCalendarCard extends HTMLElement {
     
     // Set defaults
     const now = new Date();
-    const startDate = defaultDate || now;
-    const startTime = defaultTime || startDate;
+    const startDate = defaultDate ? new Date(defaultDate) : now;
+    const hasExplicitDefaultTime = defaultTime instanceof Date;
+    const startTime = hasExplicitDefaultTime ? new Date(defaultTime) : new Date(startDate);
     
     // Round to next half hour for timed events
-    if (!defaultDate || defaultDate.getHours() !== 0) {
+    if (!hasExplicitDefaultTime && (!defaultDate || defaultDate.getHours() !== 0)) {
       const minutes = startTime.getMinutes();
       if (minutes < 30) {
         startTime.setMinutes(30);


### PR DESCRIPTION
### Motivation
- Creating a new event from a schedule time slot should pre-populate the dialog with the exact slot start time instead of being auto-shifted to the next half-hour.

### Description
- Pass the clicked slot time into the create-event modal by calling `showCreateEventModal(date, date)` when a schedule time-slot is clicked in the schedule view.
- Update `showCreateEventModal` defaults to clone incoming `defaultDate`/`defaultTime` and detect an explicit `defaultTime` so the auto-round-to-half-hour logic is skipped when a precise time is provided in code (change made in `skylight-calendar-card.js`).
- Preserve rounding behavior for non-explicit times and avoid mutating the original date objects by creating new `Date` instances for internal use.

### Testing
- Ran `node --check skylight-calendar-card.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6e73d79e08331bac6a2ab563aa456)