### PR TITLE
Improve event create/edit modal layout and add 'Event Options' translations

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4993,7 +4993,9 @@ class SkylightCalendarCard extends HTMLElement {
                        value="${formatDateTimeLocal(startTime)}" required />
               </div>
             </div>
+          </div>
 
+          <div id="timed-event-fields">
             <div class="form-group form-group-inline">
               <div class="form-inline-row">
                 <label class="form-label">${this.t('end')}</label>


### PR DESCRIPTION
### Motivation

- Improve the usability and responsiveness of the create/edit event modals by consolidating option controls and arranging form fields in a clearer inline layout.
- Provide a localized label for the grouped event option controls across supported languages.
- Reduce vertical spacing and make the dialog layout more compact and consistent across screen sizes.

### Description

- Add a new translation key `eventOptions` to `TRANSLATIONS` for `en`, `fr`, `de`, and `nl` and provide corresponding localized strings.
- Restructure modal form HTML for both create and edit flows to use `#create-event-form` / `#edit-event-form`, `form-inline-row`, `form-group-inline`, `form-checkbox-grid`, and `form-checkbox-row` to present calendars, title, start/end, location and option checkboxes in inline/grid layouts.
- Update CSS to support the new form structure by introducing rules for `#create-event-form`, `#edit-event-form`, `.form-inline-row`, `.form-checkbox-grid`, `.form-checkbox-row`, and other spacing/placement tweaks, and adjust `.form-actions` margin for a more compact layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8d72c8ba0833197e27f52e9e41a09)