### PR TITLE
Improve all-day and multi-day event rendering and add start-time title treatment

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4437,22 +4437,31 @@ class SkylightCalendarCard extends HTMLElement {
     };
   }
 
+  getLocalDateKey(date) {
+    return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate());
+  }
+
+  eventSpansMultipleLocalDates(eventStart, eventEnd) {
+    return this.getLocalDateKey(eventStart) !== this.getLocalDateKey(eventEnd);
+  }
+
   getScheduleVisualInfo(event) {
     const { eventStart, eventEnd, isAllDay } = this.getEventDateTimeInfo(event);
-    const durationMs = eventEnd.getTime() - eventStart.getTime();
-    const rendersAsAllDay = isAllDay || durationMs >= 24 * 60 * 60 * 1000;
+    const rendersAsAllDay = isAllDay || this.eventSpansMultipleLocalDates(eventStart, eventEnd);
+    const displayTitle = event.summary || this.t('untitledEvent');
+    const shouldIncludeStartTime = !isAllDay && rendersAsAllDay && this.shouldShowEventTime(event);
 
     return {
       eventStart,
       eventEnd,
       isAllDay,
       rendersAsAllDay,
-      displayTitle: !isAllDay && rendersAsAllDay
+      displayTitle: shouldIncludeStartTime
         ? this.t('eventTitleWithStartTime', {
-            title: event.summary || this.t('untitledEvent'),
+            title: displayTitle,
             time: this.formatScheduleTime(eventStart)
           })
-        : (event.summary || this.t('untitledEvent'))
+        : displayTitle
     };
   }
 


### PR DESCRIPTION
### Motivation
- Prevent all-day event titles from being clipped and improve layout for events spanning multiple days. 
- Show a more informative title for long events that render as all-day by including their start time. 
- Ensure both schedule (all-day) and timed event renderers use a consistent display title for combined/converted events.

### Description
- Added a new translation key `eventTitleWithStartTime` to supported languages and hooked it into display logic. 
- Introduced `getScheduleVisualInfo` and enhanced `getEventDaySegment` to support an optional `useScheduleVisualTreatment` flag and to surface `displayTitle` and `rendersAsAllDay`. 
- Updated all-day layout logic (`buildAllDayLayoutForSchedule`, `renderAllDayEventsForDay`) to use `displayTitle`, expose `visibleDaySpan`, and emit CSS variables for multi-day title width calculations. 
- Improved CSS for `.all-day-events` and `.all-day-event` to avoid clipping, add positioning for titles that span multiple days, and added `leading-span-title`/`spans-multiple-days` styles to manage z-index and truncation.
- Updated timed event rendering (`renderTimedEventsForDay`) to use the new `displayTitle` when available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba30b04e6c83318a26ec594cb9dacb)