### PR TITLE
Fix schedule view handling for overnight timed events

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4445,9 +4445,14 @@ class SkylightCalendarCard extends HTMLElement {
     return this.getLocalDateKey(eventStart) !== this.getLocalDateKey(eventEnd);
   }
 
+  shouldRenderTimedEventAsAllDayInSchedule(eventStart, eventEnd) {
+    const durationMs = eventEnd.getTime() - eventStart.getTime();
+    return durationMs >= 86400000 && this.eventSpansMultipleLocalDates(eventStart, eventEnd);
+  }
+
   getScheduleVisualInfo(event) {
     const { eventStart, eventEnd, isAllDay } = this.getEventDateTimeInfo(event);
-    const rendersAsAllDay = isAllDay || this.eventSpansMultipleLocalDates(eventStart, eventEnd);
+    const rendersAsAllDay = isAllDay || this.shouldRenderTimedEventAsAllDayInSchedule(eventStart, eventEnd);
     const displayTitle = event.summary || this.t('untitledEvent');
     const shouldIncludeStartTime = !isAllDay && rendersAsAllDay && this.shouldShowEventTime(event);
 


### PR DESCRIPTION
### Motivation
- Overnight timed events that cross midnight but last less than 24 hours were being treated as all-day in schedule view, which moves them to the all-day lane instead of their timeslots.

### Description
- Add `shouldRenderTimedEventAsAllDayInSchedule(eventStart, eventEnd)` to classify timed events as all-day in schedule only when their duration is >= 24 hours and they span multiple local dates.
- Update `getScheduleVisualInfo` to use the new helper so true all-day events keep current behavior while sub-24-hour overnight events remain in timeslots.
- Change implemented in `skylight-calendar-card.js` and scoped to the schedule rendering logic to avoid affecting other views.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc7e26c4908331b449b7f8a57b1866)