### PR TITLE
Handle missing end times, unify recurring WS payload, and adjust form validation

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4969,6 +4969,23 @@ class SkylightCalendarCard extends HTMLElement {
     endInput.addEventListener('change', recalculateDuration);
   }
 
+  resolveTimedEventRange(startValue, endValue, fallbackDurationMs = 60 * 60 * 1000) {
+    const start = this.parsePossiblyLocalDateTime(startValue);
+    if (!(start instanceof Date) || Number.isNaN(start.getTime())) {
+      return { start: null, end: null };
+    }
+
+    const parsedEnd = endValue ? this.parsePossiblyLocalDateTime(endValue) : null;
+    if (parsedEnd instanceof Date && !Number.isNaN(parsedEnd.getTime())) {
+      return { start, end: parsedEnd };
+    }
+
+    return {
+      start,
+      end: new Date(start.getTime() + fallbackDurationMs)
+    };
+  }
+
   showCreateEventModal(defaultDate = null, defaultTime = null) {
 
     const modal = this.shadowRoot.getElementById('event-modal');
@@ -5156,7 +5173,7 @@ class SkylightCalendarCard extends HTMLElement {
               <div class="form-inline-row">
                 <label class="form-label">${this.t('end')}</label>
                 <input type="datetime-local" class="form-input" id="event-end"
-                       value="${formatDateTimeLocal(endTime)}" required />
+                       value="${formatDateTimeLocal(endTime)}" />
               </div>
             </div>
           </div>
@@ -5310,14 +5327,12 @@ class SkylightCalendarCard extends HTMLElement {
         const startDateTime = this.shadowRoot.getElementById('event-start').value;
         const endDateTime = this.shadowRoot.getElementById('event-end').value;
 
-        if (!startDateTime || !endDateTime) {
+        if (!startDateTime) {
           this.showFormError(errorDiv, this.t('startEndTimesRequired'));
           return;
         }
 
-        // Convert to ISO format
-        const start = this.parsePossiblyLocalDateTime(startDateTime);
-        const end = this.parsePossiblyLocalDateTime(endDateTime);
+        const { start, end } = this.resolveTimedEventRange(startDateTime, endDateTime);
 
         if (end <= start) {
           this.showFormError(errorDiv, this.t('endTimeBeforeStart'));
@@ -5545,7 +5560,7 @@ class SkylightCalendarCard extends HTMLElement {
               <div class="form-inline-row">
                 <label class="form-label">${this.t('end')}</label>
                 <input type="datetime-local" class="form-input" id="event-end"
-                       value="${formatDateTimeLocal(endDate)}" required />
+                       value="${formatDateTimeLocal(endDate)}" />
               </div>
             </div>
           </div>
@@ -5694,15 +5709,14 @@ class SkylightCalendarCard extends HTMLElement {
       } else {
         const startDateTime = this.shadowRoot.getElementById('event-start').value;
         const endDateTime = this.shadowRoot.getElementById('event-end').value;
+        const existingDurationMs = Math.max(endDate.getTime() - startDate.getTime(), 60 * 1000);
 
-        if (!startDateTime || !endDateTime) {
+        if (!startDateTime) {
           this.showFormError(errorDiv, this.t('startEndTimesRequired'));
           return;
         }
 
-        // Convert to ISO format
-        const start = this.parsePossiblyLocalDateTime(startDateTime);
-        const end = this.parsePossiblyLocalDateTime(endDateTime);
+        const { start, end } = this.resolveTimedEventRange(startDateTime, endDateTime, existingDurationMs);
 
         if (end <= start) {
           this.showFormError(errorDiv, this.t('endTimeBeforeStart'));
@@ -6013,44 +6027,34 @@ class SkylightCalendarCard extends HTMLElement {
     if (isRecurring) {
       baseData.rrule = eventData.rrule;
 
-      const dtstart = baseData.start_date_time || baseData.start_date;
-      const dtend = baseData.end_date_time || baseData.end_date;
-
       // HA recurring event support is exposed through Calendar WebSocket API.
-      // Primary payload shape expects event.dtstart / event.dtend.
-      const wsPayloadCandidates = [
-        {
-          type: 'calendar/event/create',
-          entity_id: calendarId,
-          event: {
-            summary: baseData.summary,
-            location: baseData.location,
-            description: baseData.description,
-            rrule: baseData.rrule,
-            dtstart,
-            dtend
-          }
-        },
-        { type: 'calendar/event/create', ...baseData }
-      ];
-
-      let lastWsError = null;
-      for (const payload of wsPayloadCandidates) {
-        try {
-          if (this._hass.connection?.sendMessagePromise) {
-            await this._hass.connection.sendMessagePromise(payload);
-            return;
-          }
-        } catch (error) {
-          lastWsError = error;
+      // WebSocket schema expects event.dtstart / event.dtend (not start/end keys).
+      const wsPayload = {
+        type: 'calendar/event/create',
+        entity_id: calendarId,
+        event: {
+          summary: baseData.summary,
+          location: baseData.location,
+          description: baseData.description,
+          rrule: baseData.rrule,
+          dtstart: eventData.start.dateTime || eventData.start.date,
+          dtend: eventData.end.dateTime || eventData.end.date
         }
+      };
+
+      try {
+        if (this._hass.connection?.sendMessagePromise) {
+          await this._hass.connection.sendMessagePromise(wsPayload);
+          return;
+        }
+      } catch (error) {
+        console.error('WebSocket recurring create failed:', error);
+        throw new Error(error?.message || this.t('createEventServiceError'));
       }
 
-      console.error('WebSocket recurring create failed:', lastWsError);
-      throw new Error(lastWsError?.message || this.t('createEventServiceError'));
+      throw new Error(this.t('createEventServiceError'));
     }
 
-    // Non-recurring events continue to use the traditional service call.
     try {
       await this._hass.callService('calendar', 'create_event', baseData);
     } catch (error) {


### PR DESCRIPTION
### Motivation
- Ensure timed events can be created when the end time is omitted by inferring a sensible end time instead of failing validation. 
- Fix and consolidate the WebSocket payload shape for creating recurring events so it matches the Calendar API expectaction (`event.dtstart` / `event.dtend`).
- Relax form constraints for end inputs to allow creating events with only a start time provided.

### Description
- Added `resolveTimedEventRange(startValue, endValue, fallbackDurationMs = 60 * 60 * 1000)` to parse start/end inputs and synthesize an end when missing using a fallback duration (default 1 hour).
- Reworked create/edit flows to use `resolveTimedEventRange`, including passing an existing event duration (`existingDurationMs`) when editing to preserve duration where appropriate.
- Removed `required` attribute from end `datetime-local` inputs and tightened validation to require only a start time while ensuring the resolved end is after the start.
- Simplified recurring event WebSocket creation to emit a single well-formed payload with `event.dtstart` and `event.dtend`, and improved error handling for the WS attempt while preserving the non-recurring `calendar.create_event` service call.

### Testing
- Ran linting via `npm run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c027364c308331a5f189d96809d407)