### PR TITLE
Fix minor formatting issue in create event modal.

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -5175,9 +5175,7 @@ class SkylightCalendarCard extends HTMLElement {
                        value="${formatDateTimeLocal(startTime)}" required />
               </div>
             </div>
-          </div>
 
-          <div id="timed-event-fields">
             <div class="form-group form-group-inline">
               <div class="form-inline-row">
                 <label class="form-label">${this.t('end')}</label>


### PR DESCRIPTION
### Motivation
- Formatting glitch in the Create Event modal caused the end-time for the timed date-time input to remain visible even when all-day event was checked.
- Created confusion and was an obvious error.

### Fix
- Re-group the stand and end date-time inputs, which should have been grouped to disappear together upon checking the All-Day Event box.