### PR TITLE
Replace shadow DOM usage with host root (_root) and add DOM helper

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3265,6 +3265,12 @@ class SkylightCalendarCard extends HTMLElement {
         ${this.getStyles()}
       </style>
 
+      ${this._config.uix?.style ? `
+        <style class="uix-style">
+          ${this._config.uix.style}
+        </style>
+      ` : ''}
+
       <div class="calendar-container ${this._isDarkMode ? 'dark-mode' : ''} ${hasCustomBackground ? 'custom-background' : ''}" style="${containerStyle}">
         ${this._config.compact_header ? this.renderCompactHeader() : this.renderStandardHeader()}
 


### PR DESCRIPTION
### Motivation
- Move rendering and DOM access out of a shadow root into the host element to support environments where shadow DOM is not used and simplify DOM querying.
- Provide a consistent accessor for finding elements by id across the component via a small helper to avoid repeated `shadowRoot` checks.
- Ensure UI measurements and event wiring work when rendering into the host element rather than a shadow root.

### Description
- Replaced `this.attachShadow({ mode: 'open' })` with `this._root = this` and added a helper `getRootElementById(id)` to centralize id lookups.
- Replaced direct `this.shadowRoot` checks and queries throughout the file with `this._root` or using `getRootElementById`, and adjusted guard checks accordingly.
- Updated rendering target from `this.shadowRoot.innerHTML` to `this._root.innerHTML` and hooked up event listeners and modal/form element lookups to the new root strategy.
- Preserved existing behavior for layout measurements, event management, recurrence handling, and create/edit/delete flows while updating all DOM interactions to the host root.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4ba85b7dc8331807bee91b7362549)