### PR TITLE
Allow injecting custom CSS from `config.uix.style` into card styles

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3259,10 +3259,14 @@ class SkylightCalendarCard extends HTMLElement {
       ? '--calendar-background: transparent;'
       : '';
     const containerStyle = `${headerStyle} ${backgroundStyle} ${backgroundImageStyle}`.trim();
+    const externalStyleOverrides = typeof this._config?.uix?.style === 'string'
+      ? this._config.uix.style
+      : '';
 
     this._root.innerHTML = `
       <style>
         ${this.getStyles()}
+        ${externalStyleOverrides}
       </style>
 
       <div class="calendar-container ${this._isDarkMode ? 'dark-mode' : ''} ${hasCustomBackground ? 'custom-background' : ''}" style="${containerStyle}">


### PR DESCRIPTION
### Motivation
- Allow consumers to supply additional CSS overrides from the configuration so the card can be visually customized without modifying the source.

### Description
- Read `this._config.uix.style` into an `externalStyleOverrides` variable (using a string check) and append it to the inline `<style>` block in `this._root.innerHTML`, defaulting to an empty string when not present.

### Testing
- Ran the project build and linter which both completed successfully; no automated tests were added or changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c690f7a1a4833191c46d0ec4e61495)