### PR TITLE
Fix hide_year leaking year in cross-year period labels

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3954,6 +3954,17 @@ class SkylightCalendarCard extends HTMLElement {
 
     const formatter = new Intl.DateTimeFormat(this.getLocale(), formatOptions);
 
+    if (!includeYear) {
+      if (startDate.getTime() === endDate.getTime()) {
+        return formatter.format(startDate);
+      }
+
+      // Intl.DateTimeFormat#formatRange may still add a year when dates cross
+      // year boundaries, even when year isn't requested in format options.
+      // Build the range manually so hide_year always hides the year.
+      return `${formatter.format(startDate)} - ${formatter.format(endDate)}`;
+    }
+
     if (typeof formatter.formatRange === 'function') {
       return formatter.formatRange(startDate, endDate);
     }


### PR DESCRIPTION
### Motivation
- Ensure `hide_year: true` consistently suppresses year output in header period labels, including date ranges that cross from one year into the next where `Intl.DateTimeFormat#formatRange` may inject a year for disambiguation.

### Description
- No skills used for this change.
- Update `formatPeriodDateRange` to bypass `formatter.formatRange` when `includeYear` is `false` and instead build the `start - end` string using the same `Intl.DateTimeFormat` (month/day only) so the year is never shown.
- Preserve existing behavior for `includeYear = true`, continuing to use `formatRange` when available to retain locale-aware formatting.
- Keep single-day rendering as a single formatted date in both year-hidden and year-visible modes.

### Testing
- Ran `node --check skylight-calendar-card.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf354cefe0833183876414fc7d8164)