### PR TITLE
Fix padding issue on week-compact header

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -2386,6 +2386,7 @@ class SkylightCalendarCard extends HTMLElement {
         justify-content: center;
         gap: 10px;
         margin-top: 2px;
+		min-height: 32px;
       }
 
       .week-day-forecast,


### PR DESCRIPTION
## Fixes this header alignment issue on week-compact view:

### Before:
<img width="392" height="115" alt="image" src="https://github.com/user-attachments/assets/8539fdf1-1876-4ba8-89c2-bbe376a5396c" />

### After:
<img width="390" height="109" alt="image" src="https://github.com/user-attachments/assets/8c649c48-dbed-4ab5-88b4-9528b3c4b6e1" />
