### PR TITLE
Adjust dark-mode calendar borders and custom-background styles

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4172,7 +4172,16 @@ class SkylightCalendarCard extends HTMLElement {
       .calendar-container.dark-mode .time-slot {
         background: #353c45;
         color: #dde3ea;
-        border-color: #353c45;
+      }
+
+      .calendar-container.dark-mode .time-slot,
+      .calendar-container.dark-mode .day-time-slot {
+        border-top: 1px solid transparent !important;
+      }
+
+      .calendar-container.dark-mode .week-standard-day-header,
+      .calendar-container.dark-mode .all-day-events {
+        border-bottom-color: transparent;
       }
 
 	  .calendar-container.dark-mode .day-header {
@@ -4208,6 +4217,11 @@ class SkylightCalendarCard extends HTMLElement {
         background: #3b82f6;
         color: white;
         border-radius: 50%;
+      }
+
+      .calendar-container.dark-mode .week-standard-day-column {
+        border: 1px solid #556070;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
       }
 
       .calendar-container.dark-mode .day-cell:hover,
@@ -4367,6 +4381,16 @@ class SkylightCalendarCard extends HTMLElement {
       .calendar-container.custom-background .week-compact-container,
       .calendar-container.custom-background .calendar-badges {
         border-color: rgba(255, 255, 255, 0.35) !important;
+      }
+
+      .calendar-container.dark-mode.custom-background .time-slot,
+      .calendar-container.dark-mode.custom-background .day-time-slot {
+        border-top-color: transparent !important;
+      }
+
+      .calendar-container.dark-mode.custom-background .week-standard-day-header,
+      .calendar-container.dark-mode.custom-background .all-day-events {
+        border-bottom-color: transparent !important;
       }
 
       .calendar-container.custom-background .week-standard-day-column.today .week-standard-day-date {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4393,6 +4393,11 @@ class SkylightCalendarCard extends HTMLElement {
         border-bottom-color: transparent !important;
       }
 
+      .calendar-container.dark-mode.custom-background .week-standard-day-column {
+        border-color: transparent !important;
+        box-shadow: none !important;
+      }
+
       .calendar-container.custom-background .week-standard-day-column.today .week-standard-day-date {
         background: #3b82f6 !important;
         color: #ffffff !important;


### PR DESCRIPTION
### Motivation
- Fix inconsistent borders and visual artifacts in the dark mode calendar view, especially around time slots, all-day headers, and compact day columns, and ensure custom-background mode preserves intended transparency.

### Description
- Removed an incorrect solid `border-color` on `.calendar-container.dark-mode .time-slot` and introduced transparent top borders for `.time-slot` and `.day-time-slot` using `border-top: 1px solid transparent !important;` to prevent visible seams. 
- Made `.week-standard-day-column` in dark mode have a defined border and subtle `box-shadow` to improve day-cell separation and legibility. 
- Set `border-bottom-color: transparent` for `.week-standard-day-header` and `.all-day-events` in dark mode to eliminate unwanted divider lines. 
- Added matching overrides for `.calendar-container.dark-mode.custom-background` to keep borders transparent in custom-background mode using `!important` where needed. 

### Testing
- Ran the project's linting (`npm run lint`) and unit test suite (`npm test`) against the updated CSS and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e506a87f38833182e52565f7075ca9)