### PR TITLE
Honor hidden calendars for combined events and centralize visible-color logic

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4983,7 +4983,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     weekDays.forEach((date) => {
       this.getEventsForDay(date).forEach((event) => {
-        if (this._hiddenCalendars.has(event.entityId)) {
+        if (this.getVisibleCalendarColorsForEvent(event).length === 0) {
           return;
         }
 
@@ -5016,7 +5016,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     weekDays.forEach((date, dayIndex) => {
       this.getEventsForDay(date).forEach(event => {
-        if (this._hiddenCalendars.has(event.entityId)) {
+        if (this.getVisibleCalendarColorsForEvent(event).length === 0) {
           return;
         }
 
@@ -6004,6 +6004,15 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getVisibleCalendarColorsForEvent(event) {
+    if (event.isCombinedCalendarEvent && Array.isArray(event.sourceEntityIds)) {
+      const hasVisibleSourceCalendar = event.sourceEntityIds.some((entityId) => !this._hiddenCalendars.has(entityId));
+      if (!hasVisibleSourceCalendar) {
+        return [];
+      }
+    } else if (this._hiddenCalendars.has(event.entityId)) {
+      return [];
+    }
+
     const backgroundColors = this.getEventStyleOverrides(event)?.backgroundColors || [];
     if (backgroundColors.length > 0) {
       return backgroundColors;


### PR DESCRIPTION
### Motivation
- Ensure events aggregated from multiple source calendars respect per-calendar visibility when determining schedule hours and all-day layout. 
- Centralize the logic that decides whether an event should be considered visible and which colors to use. 
- Allow background color overrides to continue to take precedence while properly filtering out hidden source calendars for combined events.

### Description
- Replaced direct checks of `this._hiddenCalendars.has(event.entityId)` with a visibility check using `getVisibleCalendarColorsForEvent(event).length === 0` in `getScheduleHourRangeForWeek` and `buildAllDayLayoutForSchedule` to account for combined events. 
- Extended `getVisibleCalendarColorsForEvent` to short-circuit when a combined event has no visible source calendars and to honor `backgroundColors` overrides before falling back to source-calendar colors. 
- Updated combined-event color resolution to filter out hidden `sourceCalendars` and return an empty array when all sources are hidden, preserving existing single-calendar behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5552231fc83318be3b58b81e8c4fb)