### PR TITLE
Use CSS variables and ::after pseudo-element for conditional day borders

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1571,8 +1571,8 @@ class SkylightCalendarCard extends HTMLElement {
     if (dayStyle.border_color || dayStyle.border_width) {
       const borderWidth = dayStyle.border_width || '2px';
       const borderColor = dayStyle.border_color || 'var(--divider-color, #d1d5db)';
-      styles.push(`border: ${borderWidth} solid ${borderColor} !important`);
-      styles.push('box-sizing: border-box');
+      styles.push(`--day-style-border-width: ${borderWidth}`);
+      styles.push(`--day-style-border-color: ${borderColor}`);
     }
     const classNames = ['day-style-rule'];
     if (dayStyle.background) classNames.push('day-style-has-background');
@@ -2805,6 +2805,27 @@ class SkylightCalendarCard extends HTMLElement {
       .week-standard-day-column.day-style-has-background .day-time-slot,
       .agenda-day-row.day-style-has-background .agenda-day-label {
         background: transparent !important;
+      }
+
+      .day-cell.day-style-has-border,
+      .week-day-column.day-style-has-border,
+      .week-standard-day-column.day-style-has-border,
+      .agenda-day-row.day-style-has-border {
+        position: relative;
+      }
+
+      .day-cell.day-style-has-border::after,
+      .week-day-column.day-style-has-border::after,
+      .week-standard-day-column.day-style-has-border::after,
+      .agenda-day-row.day-style-has-border::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border: var(--day-style-border-width, 2px) solid var(--day-style-border-color, var(--divider-color, #d1d5db));
+        border-radius: inherit;
+        box-sizing: border-box;
+        pointer-events: none;
+        z-index: 2;
       }
 
       .day-number {


### PR DESCRIPTION
### Motivation
- Prevent conditional borders from affecting layout and element sizing when applied to day cells and columns.  
- Expose border width and color as CSS variables so styles can be consistently applied and overridden.

### Description
- Stop injecting inline `border` and `box-sizing` styles and instead set `--day-style-border-width` and `--day-style-border-color` variables.  
- Add CSS rules that set `position: relative` on elements with `day-style-has-border` and draw the border via a `::after` pseudo-element using the new variables.  
- Ensure the pseudo-element uses `pointer-events: none`, `box-sizing: border-box`, and `border-radius: inherit` so it doesn't interfere with interactions and matches element shape.  
- Preserve existing conditional background and opacity handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6fe30abbc83319ee19767204bf814)