### PR TITLE
Add local custom event colors

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -62,10 +62,15 @@ const TRANSLATIONS = {
       customColorSeriesHint: 'Choose a local-only color for this recurring series.',
       clearCustomColor: 'Clear Custom Color',
       recentColors: 'Recent Colors',
+      customColorPalette: 'Palette',
+      customColorPicker: 'Color Picker',
       customColorInput: 'Custom Color',
       hexColor: 'Hex Color',
+      colorBrightness: 'Brightness',
       applyCustomColor: 'Apply Color',
       invalidHexColor: 'Enter a valid 6-digit hex color.',
+      removeRecentColor: 'Remove recent color',
+      customColorAdminRequired: 'Shared custom colors require an administrator account with dashboard write access. Changes from this account stay local to this device.',
       usingDefaultColor: 'Using default styling',
       saveChanges: 'Save Changes',
       saving: 'Saving...',
@@ -522,6 +527,17 @@ class SkylightCalendarCard extends HTMLElement {
     this._customEventColors = {}; // Track local-only custom event colors
     this._recentCustomColors = []; // Track recently used custom colors
     this._resolvedPreferenceStorageKey = null; // Track the resolved storage slot across card reconfiguration
+    this._sharedPreferenceSyncInFlight = null; // Track dashboard-backed preference persistence
+    this._sharedPreferenceSaveTimer = null; // Debounce shared preference writes so UI updates can stay optimistic
+    this._queuedSharedPreferenceState = null; // Track the latest shared preference payload waiting to be saved
+    this._sharedPreferenceSaveDebounceMs = 1200; // Delay shared writes enough to keep local interactions effectively instant
+    this._pendingSharedPreferenceCardKey = null; // Track the shared card key for unsaved optimistic preference overlays
+    this._pendingSharedCustomEventColors = null; // Track unsaved shared custom event colors shown immediately in the UI
+    this._pendingSharedRecentCustomColors = null; // Track unsaved shared recent colors shown immediately in the UI
+    this._sharedPreferenceMigrationAttempted = false; // Avoid repeated shared preference migration attempts
+    this._frontendUserDataLoadInFlight = null; // Track per-user shared preference loads
+    this._sharedUserDataCustomEventColors = {}; // Track per-user shared custom colors synced via HA frontend user data
+    this._sharedUserDataRecentCustomColors = []; // Track per-user shared recent colors synced via HA frontend user data
     this._calendarCapabilities = {}; // Track calendar capabilities
     this._activeLanguage = DEFAULT_LANGUAGE;
     this._hasCustomTitle = false;
@@ -1035,6 +1051,8 @@ class SkylightCalendarCard extends HTMLElement {
     const normalizedDayStyles = this.normalizeDayStyles(config.day_styles || []);
     const normalizedHeaderColor = this.normalizeSingleColor(config.header_color);
     const normalizedHeaderTextColor = this.normalizeSingleColor(config.header_text_color);
+    const normalizedSharedCustomEventColors = this.normalizePreferenceColorMap(config.shared_custom_event_colors || {});
+    const normalizedSharedRecentCustomColors = this.normalizePreferenceColorList(config.shared_recent_custom_colors || []);
     const hasConfiguredHeaderBackgroundOpacity = config.header_background_opacity !== undefined && config.header_background_opacity !== null && config.header_background_opacity !== '';
     const normalizedHeaderBackgroundOpacity = hasConfiguredHeaderBackgroundOpacity
       ? this.normalizeBackgroundOpacity(config.header_background_opacity, 0)
@@ -1103,6 +1121,8 @@ class SkylightCalendarCard extends HTMLElement {
       event_font_colors: normalizedEventFontColors, // Per-calendar font colors for event bubble text
       event_styles: normalizedEventStyles, // Per-event styling rules with match logic
       day_styles: normalizedDayStyles, // Per-day styling rules
+      shared_custom_event_colors: normalizedSharedCustomEventColors, // Dashboard-shared custom event colors
+      shared_recent_custom_colors: normalizedSharedRecentCustomColors, // Dashboard-shared recent custom colors
       hide_times_for_calendars: config.hide_times_for_calendars || [], // Hide times in schedule view for specific calendars
       show_current_time_bar: config.show_current_time_bar || false, // Show a "now" indicator in schedule view
       use_24hr_schedule: config.use_24hr_schedule ?? false, // Use 24-hour time notation in schedule view
@@ -1142,11 +1162,14 @@ class SkylightCalendarCard extends HTMLElement {
         ? config.header_weather_sensor.trim()
         : null,
       event_styles: normalizedEventStyles,
-      day_styles: normalizedDayStyles
+      day_styles: normalizedDayStyles,
+      shared_custom_event_colors: normalizedSharedCustomEventColors,
+      shared_recent_custom_colors: normalizedSharedRecentCustomColors
     };
     this._resolvedPreferenceStorageKey = this._config.preference_storage_key
       ? null
       : previousResolvedPreferenceStorageKey;
+    this._sharedPreferenceMigrationAttempted = false;
     this._viewMode = this._config.default_view;
     this.applyThemeMode(this._config.color_scheme);
     this._hiddenCalendars = new Set(
@@ -1221,6 +1244,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
     }
 
+    this.maybePromoteLocalPreferencesToShared();
     this.ensureWeatherForecastSubscription();
     this.refreshWeatherForecastData();
 
@@ -1270,6 +1294,29 @@ class SkylightCalendarCard extends HTMLElement {
       }
       return acc;
     }, {});
+  }
+
+  normalizePreferenceColorMap(colorMap) {
+    if (!colorMap || typeof colorMap !== 'object' || Array.isArray(colorMap)) return {};
+
+    return Object.entries(colorMap).reduce((acc, [storageKey, color]) => {
+      const normalizedKey = String(storageKey || '').trim();
+      const normalizedColor = this.colorToHex(color) || this.normalizeSingleColor(color);
+      if (normalizedKey && normalizedColor) {
+        acc[normalizedKey] = normalizedColor;
+      }
+      return acc;
+    }, {});
+  }
+
+  normalizePreferenceColorList(colors) {
+    if (!Array.isArray(colors)) return [];
+
+    return colors
+      .map((color) => this.colorToHex(color) || this.normalizeHexColorInput(color) || this.normalizeSingleColor(color))
+      .filter((color) => typeof color === 'string' && !!color)
+      .filter((color, index, array) => array.indexOf(color) === index)
+      .slice(0, 12);
   }
 
   normalizeSingleColor(colorValue) {
@@ -1849,11 +1896,18 @@ class SkylightCalendarCard extends HTMLElement {
     if (!event) return null;
 
     const seriesKey = this.getCustomColorSeriesKey(event);
+    const sharedCustomEventColors = this.getEffectiveSharedCustomEventColors();
+    if (seriesKey && sharedCustomEventColors[seriesKey]) {
+      return sharedCustomEventColors[seriesKey];
+    }
     if (seriesKey && this._customEventColors[seriesKey]) {
       return this._customEventColors[seriesKey];
     }
 
     const eventKey = this.getCustomColorEventKey(event);
+    if (eventKey && sharedCustomEventColors[eventKey]) {
+      return sharedCustomEventColors[eventKey];
+    }
     if (eventKey && this._customEventColors[eventKey]) {
       return this._customEventColors[eventKey];
     }
@@ -1869,7 +1923,7 @@ class SkylightCalendarCard extends HTMLElement {
     return !!this.getStoredCustomColor(event);
   }
 
-  setStoredCustomColor(event, color) {
+  setLocalStoredCustomColor(event, color) {
     const storageKey = this.getCustomColorSeriesKey(event) || this.getCustomColorEventKey(event);
     const normalizedColor = this.colorToHex(color) || this.normalizeSingleColor(color);
     if (!storageKey || !normalizedColor) {
@@ -1885,7 +1939,7 @@ class SkylightCalendarCard extends HTMLElement {
     return true;
   }
 
-  clearStoredCustomColor(event) {
+  clearLocalStoredCustomColor(event) {
     const candidateKeys = [
       this.getCustomColorSeriesKey(event),
       this.getCustomColorEventKey(event)
@@ -1958,7 +2012,62 @@ class SkylightCalendarCard extends HTMLElement {
     return /^#[0-9a-fA-F]{6}$/.test(withHash) ? withHash.toUpperCase() : null;
   }
 
+  hexToHsv(hexColor) {
+    const normalizedHex = this.normalizeHexColorInput(hexColor) || '#3B82F6';
+    const r = parseInt(normalizedHex.slice(1, 3), 16) / 255;
+    const g = parseInt(normalizedHex.slice(3, 5), 16) / 255;
+    const b = parseInt(normalizedHex.slice(5, 7), 16) / 255;
+
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const delta = max - min;
+
+    let h = 0;
+    if (delta !== 0) {
+      if (max === r) h = ((g - b) / delta) % 6;
+      else if (max === g) h = (b - r) / delta + 2;
+      else h = (r - g) / delta + 4;
+      h = Math.round(h * 60);
+      if (h < 0) h += 360;
+    }
+
+    return {
+      h,
+      s: max === 0 ? 0 : delta / max,
+      v: max
+    };
+  }
+
+  hsvToHex(h, s, v) {
+    const hue = ((Number(h) % 360) + 360) % 360;
+    const sat = Math.max(0, Math.min(1, Number(s)));
+    const val = Math.max(0, Math.min(1, Number(v)));
+
+    const c = val * sat;
+    const x = c * (1 - Math.abs(((hue / 60) % 2) - 1));
+    const m = val - c;
+
+    let r = 0;
+    let g = 0;
+    let b = 0;
+
+    if (hue < 60) [r, g, b] = [c, x, 0];
+    else if (hue < 120) [r, g, b] = [x, c, 0];
+    else if (hue < 180) [r, g, b] = [0, c, x];
+    else if (hue < 240) [r, g, b] = [0, x, c];
+    else if (hue < 300) [r, g, b] = [x, 0, c];
+    else [r, g, b] = [c, 0, x];
+
+    const toHexChannel = (channel) => Math.round((channel + m) * 255).toString(16).padStart(2, '0');
+    return `#${toHexChannel(r)}${toHexChannel(g)}${toHexChannel(b)}`.toUpperCase();
+  }
+
   getRecentCustomColors() {
+    const sharedRecentColors = this.getEffectiveSharedRecentCustomColors();
+    if (sharedRecentColors.length > 0) {
+      return sharedRecentColors;
+    }
+
     return Array.isArray(this._recentCustomColors) ? this._recentCustomColors : [];
   }
 
@@ -1972,6 +2081,477 @@ class SkylightCalendarCard extends HTMLElement {
       normalizedColor,
       ...this.getRecentCustomColors().filter((entry) => entry !== normalizedColor)
     ].slice(0, 12);
+  }
+
+  removeLocalRecentCustomColor(color) {
+    const normalizedColor = this.colorToHex(color) || this.normalizeHexColorInput(color);
+    if (!normalizedColor) {
+      return false;
+    }
+
+    const nextRecentCustomColors = this.getRecentCustomColors().filter((entry) => entry !== normalizedColor);
+    if (nextRecentCustomColors.length === this.getRecentCustomColors().length) {
+      return false;
+    }
+
+    this._recentCustomColors = nextRecentCustomColors;
+    this.persistPreferences();
+    return true;
+  }
+
+  async saveRecentCustomColors(recentCustomColors) {
+    const normalizedRecentCustomColors = this.normalizePreferenceColorList(recentCustomColors || []);
+    const currentRecentCustomColors = this.getRecentCustomColors();
+    const isUnchanged = normalizedRecentCustomColors.length === currentRecentCustomColors.length &&
+      normalizedRecentCustomColors.every((entry, index) => entry === currentRecentCustomColors[index]);
+
+    if (isUnchanged) {
+      return true;
+    }
+
+    this._recentCustomColors = normalizedRecentCustomColors;
+    this.persistPreferences();
+    const optimisticSharedState = this.getOptimisticSharedPreferenceState({
+      sharedCustomEventColors: this.getEffectiveSharedCustomEventColors(),
+      sharedRecentCustomColors: normalizedRecentCustomColors
+    });
+    this.queueSharedPreferenceSave(optimisticSharedState);
+    return true;
+  }
+
+  async removeRecentCustomColor(color) {
+    const normalizedColor = this.colorToHex(color) || this.normalizeHexColorInput(color);
+    if (!normalizedColor) {
+      return false;
+    }
+
+    const nextRecentCustomColors = this.getRecentCustomColors().filter((entry) => entry !== normalizedColor);
+    if (nextRecentCustomColors.length === this.getRecentCustomColors().length) {
+      return false;
+    }
+
+    return this.saveRecentCustomColors(nextRecentCustomColors);
+  }
+
+  hasSharedCustomColorWriteAccess() {
+    return this._hass?.user?.is_admin === true;
+  }
+
+  getSharedPreferenceCardKey() {
+    const explicitPreferenceStorageKey = typeof this._config?.preference_storage_key === 'string'
+      ? this._config.preference_storage_key.trim()
+      : '';
+    if (explicitPreferenceStorageKey) {
+      return explicitPreferenceStorageKey;
+    }
+
+    const sharedKey = typeof this._config?._shared_config_key === 'string'
+      ? this._config._shared_config_key.trim()
+      : '';
+    if (sharedKey) {
+      return sharedKey;
+    }
+
+    return null;
+  }
+
+  createSharedPreferenceCardKey() {
+    return `skylight-shared-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  getCurrentDashboardRoutePath() {
+    const pathname = String(window.location?.pathname || '').split('?')[0].split('#')[0];
+    if (pathname && pathname !== '/') {
+      return pathname.startsWith('/') ? pathname : `/${pathname}`;
+    }
+
+    const hashPath = String(window.location?.hash || '').replace(/^#/, '').split('?')[0];
+    if (hashPath) {
+      return hashPath.startsWith('/') ? hashPath : `/${hashPath}`;
+    }
+
+    return '/';
+  }
+
+  getDashboardConfigUrlPath() {
+    const panels = this._hass?.panels || {};
+    const routePath = this.getCurrentDashboardRoutePath();
+    const dashboardCandidates = Object.values(panels)
+      .filter((panel) => panel?.component_name === 'lovelace' && typeof panel.url_path === 'string' && panel.url_path.trim())
+      .map((panel) => String(panel.url_path).trim().replace(/^\/+/, ''))
+      .filter(Boolean)
+      .sort((a, b) => b.length - a.length);
+
+    const matchedDashboard = dashboardCandidates.find((urlPath) => {
+      const prefixedPath = `/${urlPath}`;
+      return routePath === prefixedPath || routePath.startsWith(`${prefixedPath}/`);
+    });
+
+    if (matchedDashboard) {
+      return matchedDashboard;
+    }
+
+    return this.getDashboardScopeKey();
+  }
+
+  cloneConfigValue(value) {
+    if (typeof structuredClone === 'function') {
+      return structuredClone(value);
+    }
+
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  cardConfigMatchesSharedPreferenceTarget(cardConfig) {
+    if (!cardConfig || cardConfig.type !== 'custom:skylight-calendar-card') {
+      return false;
+    }
+
+    const explicitPreferenceStorageKey = typeof this._config?.preference_storage_key === 'string'
+      ? this._config.preference_storage_key.trim()
+      : '';
+    if (explicitPreferenceStorageKey && cardConfig.preference_storage_key === explicitPreferenceStorageKey) {
+      return true;
+    }
+
+    const sharedCardKey = typeof this._config?._shared_config_key === 'string'
+      ? this._config._shared_config_key.trim()
+      : '';
+    if (sharedCardKey && cardConfig._shared_config_key === sharedCardKey) {
+      return true;
+    }
+
+    const currentEntities = Array.isArray(this._config?.entities) ? this._config.entities.join('|') : '';
+    const candidateEntities = Array.isArray(cardConfig.entities) ? cardConfig.entities.join('|') : '';
+    const currentTitle = String(this._config?.title || '').trim();
+    const candidateTitle = String(cardConfig.title || '').trim();
+
+    return currentEntities && currentEntities === candidateEntities && currentTitle === candidateTitle;
+  }
+
+  findSharedPreferenceCardInDashboardConfig(lovelaceConfig) {
+    const searchCards = (cards) => {
+      if (!Array.isArray(cards)) return null;
+
+      for (let index = 0; index < cards.length; index += 1) {
+        const cardConfig = cards[index];
+        if (this.cardConfigMatchesSharedPreferenceTarget(cardConfig)) {
+          return { parentArray: cards, index, cardConfig };
+        }
+
+        if (Array.isArray(cardConfig?.cards)) {
+          const nestedMatch = searchCards(cardConfig.cards);
+          if (nestedMatch) return nestedMatch;
+        }
+
+        if (cardConfig?.card) {
+          const nestedSingleMatch = searchCards([cardConfig.card]);
+          if (nestedSingleMatch) return nestedSingleMatch;
+        }
+      }
+
+      return null;
+    };
+
+    const views = Array.isArray(lovelaceConfig?.views) ? lovelaceConfig.views : [];
+    for (const view of views) {
+      const directMatch = searchCards(view?.cards);
+      if (directMatch) return directMatch;
+
+      if (Array.isArray(view?.sections)) {
+        for (const section of view.sections) {
+          const sectionMatch = searchCards(section?.cards);
+          if (sectionMatch) return sectionMatch;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  applySharedPreferenceStateToConfig(sharedCustomEventColors, sharedRecentCustomColors, sharedCardKey = null) {
+    this._config = {
+      ...this._config,
+      shared_custom_event_colors: this.normalizePreferenceColorMap(sharedCustomEventColors || {}),
+      shared_recent_custom_colors: this.normalizePreferenceColorList(sharedRecentCustomColors || []),
+      ...(sharedCardKey ? { _shared_config_key: sharedCardKey } : {})
+    };
+  }
+
+  getEffectiveSharedCustomEventColors() {
+    if (this._pendingSharedCustomEventColors !== null) {
+      return this.normalizePreferenceColorMap(this._pendingSharedCustomEventColors);
+    }
+
+    return this.normalizePreferenceColorMap(this._config?.shared_custom_event_colors || {});
+  }
+
+  getEffectiveSharedRecentCustomColors() {
+    if (this._pendingSharedRecentCustomColors !== null) {
+      return this.normalizePreferenceColorList(this._pendingSharedRecentCustomColors);
+    }
+
+    return this.normalizePreferenceColorList(this._config?.shared_recent_custom_colors || []);
+  }
+
+  sharedPreferencePayloadMatchesPending(sharedPreferenceState) {
+    if (!sharedPreferenceState) {
+      return false;
+    }
+
+    const normalizedPendingCustomEventColors = this.normalizePreferenceColorMap(this._pendingSharedCustomEventColors || {});
+    const normalizedPendingRecentCustomColors = this.normalizePreferenceColorList(this._pendingSharedRecentCustomColors || []);
+    const normalizedSharedCustomEventColors = this.normalizePreferenceColorMap(sharedPreferenceState.sharedCustomEventColors || {});
+    const normalizedSharedRecentCustomColors = this.normalizePreferenceColorList(sharedPreferenceState.sharedRecentCustomColors || []);
+    const pendingCustomKeys = Object.keys(normalizedPendingCustomEventColors).sort();
+    const sharedCustomKeys = Object.keys(normalizedSharedCustomEventColors).sort();
+
+    if ((this._pendingSharedPreferenceCardKey || null) !== (sharedPreferenceState.sharedCardKey || null)) {
+      return false;
+    }
+
+    if (pendingCustomKeys.length !== sharedCustomKeys.length) {
+      return false;
+    }
+
+    if (!pendingCustomKeys.every((key, index) => key === sharedCustomKeys[index] && normalizedPendingCustomEventColors[key] === normalizedSharedCustomEventColors[key])) {
+      return false;
+    }
+
+    if (normalizedPendingRecentCustomColors.length !== normalizedSharedRecentCustomColors.length) {
+      return false;
+    }
+
+    return normalizedPendingRecentCustomColors.every((entry, index) => entry === normalizedSharedRecentCustomColors[index]);
+  }
+
+  clearPendingSharedPreferenceOverlay(sharedPreferenceState = null) {
+    if (sharedPreferenceState && !this.sharedPreferencePayloadMatchesPending(sharedPreferenceState)) {
+      return;
+    }
+
+    this._pendingSharedPreferenceCardKey = null;
+    this._pendingSharedCustomEventColors = null;
+    this._pendingSharedRecentCustomColors = null;
+  }
+
+  getOptimisticSharedPreferenceState({ sharedCustomEventColors, sharedRecentCustomColors }) {
+    const sharedCardKey = this._pendingSharedPreferenceCardKey || this.getSharedPreferenceCardKey() || this.createSharedPreferenceCardKey();
+    const normalizedSharedCustomEventColors = this.normalizePreferenceColorMap(sharedCustomEventColors || {});
+    const normalizedSharedRecentCustomColors = this.normalizePreferenceColorList(sharedRecentCustomColors || []);
+
+    this._pendingSharedPreferenceCardKey = sharedCardKey;
+    this._pendingSharedCustomEventColors = normalizedSharedCustomEventColors;
+    this._pendingSharedRecentCustomColors = normalizedSharedRecentCustomColors;
+
+    return {
+      sharedCardKey,
+      sharedCustomEventColors: normalizedSharedCustomEventColors,
+      sharedRecentCustomColors: normalizedSharedRecentCustomColors
+    };
+  }
+
+  queueSharedPreferenceSave(sharedPreferenceState) {
+    if (!sharedPreferenceState) {
+      return false;
+    }
+
+    this._queuedSharedPreferenceState = {
+      sharedCardKey: sharedPreferenceState.sharedCardKey || this.getSharedPreferenceCardKey() || this.createSharedPreferenceCardKey(),
+      sharedCustomEventColors: this.normalizePreferenceColorMap(sharedPreferenceState.sharedCustomEventColors || {}),
+      sharedRecentCustomColors: this.normalizePreferenceColorList(sharedPreferenceState.sharedRecentCustomColors || [])
+    };
+
+    if (this._sharedPreferenceSaveTimer) {
+      clearTimeout(this._sharedPreferenceSaveTimer);
+    }
+
+    this._sharedPreferenceSaveTimer = setTimeout(() => {
+      this._sharedPreferenceSaveTimer = null;
+      void this.flushQueuedSharedPreferenceSave();
+    }, this._sharedPreferenceSaveDebounceMs);
+
+    return true;
+  }
+
+  async flushQueuedSharedPreferenceSave() {
+    if (!this._hass?.callWS) {
+      return false;
+    }
+
+    if (this._sharedPreferenceSyncInFlight) {
+      try {
+        await this._sharedPreferenceSyncInFlight;
+      } catch (error) {
+        // The current save path already logs failures; continue and retry the latest queued state.
+      }
+    }
+
+    const queuedState = this._queuedSharedPreferenceState;
+    if (!queuedState) {
+      return false;
+    }
+
+    this._queuedSharedPreferenceState = null;
+    const saveSucceeded = await this.saveSharedPreferenceState(queuedState);
+
+    if (saveSucceeded && !this._queuedSharedPreferenceState) {
+      this.clearPendingSharedPreferenceOverlay(queuedState);
+    }
+
+    if (this._queuedSharedPreferenceState) {
+      this.queueSharedPreferenceSave(this._queuedSharedPreferenceState);
+    }
+
+    return saveSucceeded;
+  }
+
+  async saveSharedPreferenceState({ sharedCustomEventColors, sharedRecentCustomColors, sharedCardKey = null }) {
+    if (!this._hass?.callWS || this._sharedPreferenceSyncInFlight) {
+      return false;
+    }
+
+    const resolvedSharedCardKey = sharedCardKey || this.getSharedPreferenceCardKey() || this.createSharedPreferenceCardKey();
+    const normalizedSharedCustomEventColors = this.normalizePreferenceColorMap(sharedCustomEventColors || {});
+    const normalizedSharedRecentCustomColors = this.normalizePreferenceColorList(sharedRecentCustomColors || []);
+    const dashboardUrlPath = this.getDashboardConfigUrlPath();
+
+    const syncPromise = (async () => {
+      try {
+        const lovelaceConfig = await this._hass.callWS({
+          type: 'lovelace/config',
+          url_path: dashboardUrlPath
+        });
+        if (!lovelaceConfig || typeof lovelaceConfig !== 'object') {
+          return false;
+        }
+
+        const nextLovelaceConfig = this.cloneConfigValue(lovelaceConfig);
+        const match = this.findSharedPreferenceCardInDashboardConfig(nextLovelaceConfig);
+        if (!match) {
+          return false;
+        }
+
+        const nextCardConfig = {
+          ...match.cardConfig,
+          _shared_config_key: resolvedSharedCardKey,
+          shared_custom_event_colors: normalizedSharedCustomEventColors,
+          shared_recent_custom_colors: normalizedSharedRecentCustomColors
+        };
+        match.parentArray[match.index] = nextCardConfig;
+
+        await this._hass.callWS({
+          type: 'lovelace/config/save',
+          url_path: dashboardUrlPath,
+          config: nextLovelaceConfig
+        });
+
+        this.applySharedPreferenceStateToConfig(normalizedSharedCustomEventColors, normalizedSharedRecentCustomColors, resolvedSharedCardKey);
+        return true;
+      } catch (error) {
+        console.warn('Failed to save shared custom color preferences to dashboard config:', error);
+        return false;
+      } finally {
+        this._sharedPreferenceSyncInFlight = null;
+      }
+    })();
+
+    this._sharedPreferenceSyncInFlight = syncPromise;
+    return syncPromise;
+  }
+
+  maybePromoteLocalPreferencesToShared() {
+    if (this._sharedPreferenceMigrationAttempted || !this._hass?.callWS) {
+      return;
+    }
+
+    this._sharedPreferenceMigrationAttempted = true;
+
+    const sharedCustomEventColors = this.getEffectiveSharedCustomEventColors();
+    const sharedRecentCustomColors = this.getEffectiveSharedRecentCustomColors();
+    const hasSharedPreferences = Object.keys(sharedCustomEventColors).length > 0 || sharedRecentCustomColors.length > 0;
+    const hasLocalPreferences = Object.keys(this._customEventColors || {}).length > 0 || (this._recentCustomColors || []).length > 0;
+
+    if (hasSharedPreferences || !hasLocalPreferences) {
+      return;
+    }
+
+    const optimisticSharedState = this.getOptimisticSharedPreferenceState({
+      sharedCustomEventColors: this._customEventColors,
+      sharedRecentCustomColors: this._recentCustomColors
+    });
+    this.queueSharedPreferenceSave(optimisticSharedState);
+  }
+
+  async setStoredCustomColor(event, color) {
+    const storageKey = this.getCustomColorSeriesKey(event) || this.getCustomColorEventKey(event);
+    const normalizedColor = this.colorToHex(color) || this.normalizeSingleColor(color);
+    if (!storageKey || !normalizedColor) {
+      return false;
+    }
+
+    const nextSharedCustomEventColors = {
+      ...this.getEffectiveSharedCustomEventColors(),
+      [storageKey]: normalizedColor
+    };
+    const nextRecentCustomColors = [
+      normalizedColor,
+      ...this.getRecentCustomColors().filter((entry) => entry !== normalizedColor)
+    ].slice(0, 12);
+
+    this._customEventColors = {
+      ...this._customEventColors,
+      [storageKey]: normalizedColor
+    };
+    this._recentCustomColors = nextRecentCustomColors;
+    this.persistPreferences();
+    const optimisticSharedState = this.getOptimisticSharedPreferenceState({
+      sharedCustomEventColors: nextSharedCustomEventColors,
+      sharedRecentCustomColors: nextRecentCustomColors
+    });
+    this.queueSharedPreferenceSave(optimisticSharedState);
+    return true;
+  }
+
+  async clearStoredCustomColor(event) {
+    const candidateKeys = [
+      this.getCustomColorSeriesKey(event),
+      this.getCustomColorEventKey(event)
+    ].filter(Boolean);
+
+    if (candidateKeys.length === 0) {
+      return false;
+    }
+
+    const nextSharedCustomEventColors = { ...this.getEffectiveSharedCustomEventColors() };
+    let sharedChanged = false;
+
+    candidateKeys.forEach((key) => {
+      if (Object.prototype.hasOwnProperty.call(nextSharedCustomEventColors, key)) {
+        delete nextSharedCustomEventColors[key];
+        sharedChanged = true;
+      }
+    });
+
+    if (sharedChanged) {
+      const nextLocalCustomEventColors = { ...this._customEventColors };
+      candidateKeys.forEach((key) => {
+        if (Object.prototype.hasOwnProperty.call(nextLocalCustomEventColors, key)) {
+          delete nextLocalCustomEventColors[key];
+        }
+      });
+
+      this._customEventColors = nextLocalCustomEventColors;
+      this.persistPreferences();
+      const optimisticSharedState = this.getOptimisticSharedPreferenceState({
+        sharedCustomEventColors: nextSharedCustomEventColors,
+        sharedRecentCustomColors: this.getRecentCustomColors()
+      });
+      this.queueSharedPreferenceSave(optimisticSharedState);
+      return true;
+    }
+
+    return this.clearLocalStoredCustomColor(event);
   }
 
   getResolvedSingleEventBackgroundColor(event, candidates = null) {
@@ -4507,6 +5087,11 @@ class SkylightCalendarCard extends HTMLElement {
         margin-top: 0;
       }
 
+      .custom-color-access-warning {
+        margin-top: 0;
+        margin-bottom: 16px;
+      }
+
       .custom-color-section-title {
         font-size: 13px;
         font-weight: 600;
@@ -4532,6 +5117,41 @@ class SkylightCalendarCard extends HTMLElement {
       .custom-color-option.selected {
         border-color: #111827;
         box-shadow: 0 0 0 3px rgba(17, 24, 39, 0.12);
+      }
+
+      .recent-custom-color-item {
+        position: relative;
+        width: 40px;
+        height: 40px;
+      }
+
+      .recent-custom-color-item .custom-color-option {
+        width: 100%;
+        height: 100%;
+      }
+
+      .remove-recent-custom-color-btn {
+        position: absolute;
+        top: -6px;
+        right: -6px;
+        width: 18px;
+        height: 18px;
+        border: none;
+        border-radius: 999px;
+        background: rgba(17, 24, 39, 0.85);
+        color: #ffffff;
+        font-size: 12px;
+        line-height: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        padding: 0;
+        box-shadow: 0 2px 6px rgba(15, 23, 42, 0.24);
+      }
+
+      .remove-recent-custom-color-btn:hover {
+        background: #111827;
       }
 
       .custom-color-current-row {
@@ -4567,32 +5187,53 @@ class SkylightCalendarCard extends HTMLElement {
 
       .custom-color-input-row {
         display: grid;
-        grid-template-columns: 56px minmax(0, 1fr) auto;
+        grid-template-columns: minmax(0, 1fr) auto;
         gap: 12px;
         align-items: center;
       }
 
-      .custom-color-picker-input {
-        width: 56px;
-        height: 44px;
-        border: none;
-        padding: 0;
-        background: transparent;
-        cursor: pointer;
+      .custom-color-picker-wrap {
+        display: grid;
+        gap: 12px;
       }
 
-      .custom-color-picker-input::-webkit-color-swatch-wrapper {
-        padding: 0;
+      .custom-color-picker-wheel {
+        position: relative;
+        width: min(260px, 100%);
+        aspect-ratio: 1;
+        margin: 0 auto;
+        border-radius: 50%;
+        touch-action: none;
+        background:
+          radial-gradient(circle at center, #ffffff 0%, rgba(255, 255, 255, 0.85) 16%, rgba(255, 255, 255, 0) 58%),
+          conic-gradient(from 0deg, #ff0000, #ff7f00, #ffff00, #00ff00, #00ffff, #0000ff, #8b00ff, #ff00ff, #ff0000);
       }
 
-      .custom-color-picker-input::-webkit-color-swatch {
-        border: 1px solid rgba(17, 24, 39, 0.12);
-        border-radius: 10px;
+      .custom-color-picker-wheel-marker {
+        position: absolute;
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        border: 2px solid #ffffff;
+        box-shadow: 0 0 0 1px rgba(17, 24, 39, 0.55);
+        transform: translate(-50%, -50%);
+        pointer-events: none;
       }
 
-      .custom-color-picker-input::-moz-color-swatch {
-        border: 1px solid rgba(17, 24, 39, 0.12);
-        border-radius: 10px;
+      .custom-color-picker-controls {
+        display: grid;
+        gap: 8px;
+      }
+
+      .custom-color-picker-label {
+        font-size: 13px;
+        font-weight: 600;
+        color: #6b7280;
+      }
+
+      .custom-color-brightness-input {
+        width: 100%;
+        accent-color: #3b82f6;
       }
 
       .custom-color-hex-input {
@@ -4920,13 +5561,19 @@ class SkylightCalendarCard extends HTMLElement {
 
       .calendar-container.dark-mode .custom-color-current-label,
       .calendar-container.dark-mode .custom-color-current-value,
-      .calendar-container.dark-mode .custom-color-section-title {
+      .calendar-container.dark-mode .custom-color-section-title,
+      .calendar-container.dark-mode .custom-color-picker-label {
         color: #d6dee8;
       }
 
       .calendar-container.dark-mode .custom-color-option.selected {
         border-color: #f8fafc;
         box-shadow: 0 0 0 3px rgba(248, 250, 252, 0.14);
+      }
+
+      .calendar-container.dark-mode .remove-recent-custom-color-btn {
+        background: rgba(248, 250, 252, 0.88);
+        color: #111827;
       }
 
       .calendar-container.dark-mode .btn-custom-color {
@@ -9074,9 +9721,11 @@ class SkylightCalendarCard extends HTMLElement {
     const modal = this.getRootElementById('event-modal');
     const content = this.getRootElementById('modal-content');
     const currentCustomColor = this.getStoredCustomColor(event);
+    const hasSharedWriteAccess = this.hasSharedCustomColorWriteAccess();
     const previewColor = currentCustomColor || this.getEventBackgroundColor(event) || event?.color || '#3b82f6';
     const normalizedCurrentCustomColor = this.colorToHex(currentCustomColor) || this.normalizeHexColorInput(currentCustomColor);
-    const initialPickerColor = (this.colorToHex(previewColor) || '#3B82F6').toLowerCase();
+    const initialPickerColor = this.colorToHex(previewColor) || '#3B82F6';
+    const initialPickerHsv = this.hexToHsv(initialPickerColor);
     const colorHint = this.isRecurringEventInstance(event) ? this.t('customColorSeriesHint') : this.t('customColorEventHint');
     const presetButtons = this.getCustomEventColorPresets()
       .map((color) => `
@@ -9090,18 +9739,31 @@ class SkylightCalendarCard extends HTMLElement {
         </button>
       `)
       .join('');
-    const recentButtons = this.getRecentCustomColors()
+    const recentCustomColorsDraft = [...this.getRecentCustomColors()];
+    let recentCustomColorsDirty = false;
+    const renderRecentButtons = () => recentCustomColorsDraft
       .map((color) => `
-        <button
-          type="button"
-          class="custom-color-option ${normalizedCurrentCustomColor === color ? 'selected' : ''}"
-          data-custom-event-color="${color}"
-          style="--custom-color-option: ${color};"
-          aria-label="${this.t('recentColors')} ${color}"
-          title="${color}">
-        </button>
+        <div class="recent-custom-color-item">
+          <button
+            type="button"
+            class="custom-color-option ${normalizedCurrentCustomColor === color ? 'selected' : ''}"
+            data-custom-event-color="${color}"
+            style="--custom-color-option: ${color};"
+            aria-label="${this.t('recentColors')} ${color}"
+            title="${color}">
+          </button>
+          <button
+            type="button"
+            class="remove-recent-custom-color-btn"
+            data-remove-custom-recent-color="${color}"
+            aria-label="${this.t('removeRecentColor')} ${color}"
+            title="${this.t('removeRecentColor')}">
+            ×
+          </button>
+        </div>
       `)
       .join('');
+    const recentButtons = renderRecentButtons();
 
     content.innerHTML = `
       <div class="modal-header">
@@ -9112,14 +9774,18 @@ class SkylightCalendarCard extends HTMLElement {
         <button class="modal-close" id="close-modal">×</button>
       </div>
       <div class="modal-body">
-        ${recentButtons ? `
-          <div class="custom-color-section">
-            <div class="custom-color-section-title">${this.t('recentColors')}</div>
-            <div class="custom-color-grid">
-              ${recentButtons}
-            </div>
+        ${!hasSharedWriteAccess ? `
+          <div class="info-banner warning custom-color-access-warning">
+            ${this.escapeHtml(this.t('customColorAdminRequired'))}
           </div>
         ` : ''}
+
+        <div class="custom-color-section" id="recent-custom-color-section" ${recentButtons ? '' : 'style="display:none;"'}>
+            <div class="custom-color-section-title">${this.t('recentColors')}</div>
+            <div class="custom-color-grid" id="recent-custom-color-grid">
+              ${recentButtons}
+            </div>
+        </div>
 
         <div class="custom-color-section">
           <div class="custom-color-section-title">${this.t('customColor')}</div>
@@ -9129,10 +9795,29 @@ class SkylightCalendarCard extends HTMLElement {
         </div>
 
         <div class="custom-color-section">
-          <div class="custom-color-section-title">${this.t('customColorInput')}</div>
+          <div class="custom-color-section-title">${this.t('customColorPicker')}</div>
+          <div class="custom-color-picker-wrap">
+            <div class="custom-color-picker-wheel" id="custom-color-picker-wheel">
+              <div class="custom-color-picker-wheel-marker" id="custom-color-picker-wheel-marker"></div>
+            </div>
+            <div class="custom-color-picker-controls">
+              <label class="custom-color-picker-label" for="custom-color-brightness-input">${this.t('colorBrightness')}</label>
+              <input
+                type="range"
+                min="5"
+                max="100"
+                step="1"
+                value="${Math.round(initialPickerHsv.v * 100)}"
+                class="custom-color-brightness-input"
+                id="custom-color-brightness-input" />
+            </div>
+          </div>
+        </div>
+
+        <div class="custom-color-section">
+          <div class="custom-color-section-title">${this.t('hexColor')}</div>
           <div class="custom-color-input-row">
-            <input type="color" class="custom-color-picker-input" id="custom-color-native-input" value="${initialPickerColor}" aria-label="${this.t('customColorInput')}">
-            <input type="text" class="form-input custom-color-hex-input" id="custom-color-hex-input" value="${initialPickerColor.toUpperCase()}" placeholder="#3F51B5" spellcheck="false" autocapitalize="characters" />
+            <input type="text" class="form-input custom-color-hex-input" id="custom-color-hex-input" value="${initialPickerColor}" placeholder="#3F51B5" spellcheck="false" autocapitalize="characters" />
             <button class="btn btn-primary" id="apply-custom-color-btn">${this.t('applyCustomColor')}</button>
           </div>
           <div id="custom-color-form-error" class="error-message custom-color-error" style="display:none;"></div>
@@ -9170,9 +9855,19 @@ class SkylightCalendarCard extends HTMLElement {
 
     const customColorPreview = this.getRootElementById('custom-color-preview');
     const customColorValue = this.getRootElementById('custom-color-current-value');
-    const customColorNativeInput = this.getRootElementById('custom-color-native-input');
     const customColorHexInput = this.getRootElementById('custom-color-hex-input');
     const customColorFormError = this.getRootElementById('custom-color-form-error');
+    const customColorPickerWheel = this.getRootElementById('custom-color-picker-wheel');
+    const customColorPickerWheelMarker = this.getRootElementById('custom-color-picker-wheel-marker');
+    const customColorBrightnessInput = this.getRootElementById('custom-color-brightness-input');
+    const recentCustomColorSection = this.getRootElementById('recent-custom-color-section');
+    const recentCustomColorGrid = this.getRootElementById('recent-custom-color-grid');
+    const pickerState = {
+      h: initialPickerHsv.h,
+      s: initialPickerHsv.s,
+      v: initialPickerHsv.v,
+      color: initialPickerColor
+    };
 
     const hideCustomColorError = () => {
       if (customColorFormError) {
@@ -9194,7 +9889,7 @@ class SkylightCalendarCard extends HTMLElement {
         return false;
       }
 
-      if (customColorNativeInput) customColorNativeInput.value = normalizedHex.toLowerCase();
+      pickerState.color = normalizedHex;
       if (customColorHexInput) customColorHexInput.value = normalizedHex;
       if (customColorPreview) customColorPreview.style.setProperty('--custom-color-preview', normalizedHex);
       if (customColorValue) customColorValue.textContent = normalizedHex;
@@ -9202,8 +9897,43 @@ class SkylightCalendarCard extends HTMLElement {
       return true;
     };
 
-    const applyCustomColorSelection = (color) => {
-      if (!this.setStoredCustomColor(event, color)) {
+    const syncCustomColorPickerUi = () => {
+      if (customColorPickerWheel && customColorPickerWheelMarker) {
+        const radius = customColorPickerWheel.clientWidth / 2;
+        const angle = ((pickerState.h - 90) * Math.PI) / 180;
+        const markerRadius = pickerState.s * radius;
+        const x = Math.cos(angle) * markerRadius;
+        const y = Math.sin(angle) * markerRadius;
+        customColorPickerWheelMarker.style.left = `calc(50% + ${x}px)`;
+        customColorPickerWheelMarker.style.top = `calc(50% + ${y}px)`;
+      }
+
+      if (customColorBrightnessInput && document.activeElement !== customColorBrightnessInput) {
+        customColorBrightnessInput.value = String(Math.round(pickerState.v * 100));
+      }
+
+      syncCustomColorDraft(pickerState.color);
+    };
+
+    const updateCustomColorPickerFromWheelEvent = (pointerEvent) => {
+      if (!customColorPickerWheel) return;
+
+      const rect = customColorPickerWheel.getBoundingClientRect();
+      const x = pointerEvent.clientX - rect.left - rect.width / 2;
+      const y = pointerEvent.clientY - rect.top - rect.height / 2;
+      const radius = rect.width / 2;
+      const distance = Math.min(Math.sqrt((x * x) + (y * y)), radius);
+
+      pickerState.s = radius > 0 ? distance / radius : 0;
+      const hue = ((Math.atan2(y, x) * 180) / Math.PI) + 90;
+      pickerState.h = hue < 0 ? hue + 360 : hue;
+      pickerState.color = this.hsvToHex(pickerState.h, pickerState.s, pickerState.v);
+      syncCustomColorPickerUi();
+    };
+
+    const applyCustomColorSelection = async (color) => {
+      await persistQueuedRecentCustomColors();
+      if (!await this.setStoredCustomColor(event, color)) {
         showCustomColorError(this.t('invalidHexColor'));
         return;
       }
@@ -9221,42 +9951,165 @@ class SkylightCalendarCard extends HTMLElement {
       }
     };
 
-    this.getRootElementById('close-modal')?.addEventListener('click', closeCustomColorModal);
-    this.getRootElementById('cancel-custom-color-btn')?.addEventListener('click', closeCustomColorModal);
+    const persistQueuedRecentCustomColors = async () => {
+      if (!recentCustomColorsDirty) {
+        return true;
+      }
 
-    this._root.querySelectorAll('[data-custom-event-color]').forEach((button) => {
-      button.addEventListener('click', () => {
-        applyCustomColorSelection(button.getAttribute('data-custom-event-color'));
+      const saved = await this.saveRecentCustomColors(recentCustomColorsDraft);
+      if (saved) {
+        recentCustomColorsDirty = false;
+      }
+      return saved;
+    };
+
+    const bindRecentCustomColorControls = () => {
+      recentCustomColorGrid?.querySelectorAll('[data-custom-event-color]').forEach((button) => {
+        button.addEventListener('click', async () => {
+          await applyCustomColorSelection(button.getAttribute('data-custom-event-color'));
+        });
       });
+
+      recentCustomColorGrid?.querySelectorAll('[data-remove-custom-recent-color]').forEach((button) => {
+        button.addEventListener('click', (clickEvent) => {
+          clickEvent.preventDefault();
+          clickEvent.stopPropagation();
+
+          const normalizedColor = this.colorToHex(button.getAttribute('data-remove-custom-recent-color')) ||
+            this.normalizeHexColorInput(button.getAttribute('data-remove-custom-recent-color'));
+          if (!normalizedColor) {
+            return;
+          }
+
+          const nextRecentCustomColors = recentCustomColorsDraft.filter((entry) => entry !== normalizedColor);
+          if (nextRecentCustomColors.length === recentCustomColorsDraft.length) {
+            return;
+          }
+
+          recentCustomColorsDraft.splice(0, recentCustomColorsDraft.length, ...nextRecentCustomColors);
+          recentCustomColorsDirty = true;
+          syncRecentCustomColorDraftUi();
+        });
+      });
+    };
+
+    const syncRecentCustomColorDraftUi = () => {
+      if (!recentCustomColorSection || !recentCustomColorGrid) {
+        return;
+      }
+
+      if (recentCustomColorsDraft.length === 0) {
+        recentCustomColorSection.style.display = 'none';
+        recentCustomColorGrid.innerHTML = '';
+        return;
+      }
+
+      recentCustomColorSection.style.display = '';
+      recentCustomColorGrid.innerHTML = renderRecentButtons();
+      bindRecentCustomColorControls();
+    };
+
+    this.getRootElementById('close-modal')?.addEventListener('click', async () => {
+      await persistQueuedRecentCustomColors();
+      closeCustomColorModal();
+    });
+    this.getRootElementById('cancel-custom-color-btn')?.addEventListener('click', async () => {
+      await persistQueuedRecentCustomColors();
+      closeCustomColorModal();
     });
 
-    customColorNativeInput?.addEventListener('input', (inputEvent) => {
-      syncCustomColorDraft(inputEvent.target.value);
+    this._root.querySelectorAll('[data-custom-event-color]').forEach((button) => {
+      if (button.closest('#recent-custom-color-grid')) {
+        return;
+      }
+      button.addEventListener('click', async () => {
+        await applyCustomColorSelection(button.getAttribute('data-custom-event-color'));
+      });
+    });
+    bindRecentCustomColorControls();
+
+    if (customColorPickerWheel) {
+      let isDraggingPicker = false;
+      let activePointerId = null;
+
+      customColorPickerWheel.addEventListener('pointerdown', (pointerEvent) => {
+        isDraggingPicker = true;
+        activePointerId = pointerEvent.pointerId;
+        customColorPickerWheel.setPointerCapture(pointerEvent.pointerId);
+        updateCustomColorPickerFromWheelEvent(pointerEvent);
+      });
+
+      customColorPickerWheel.addEventListener('pointermove', (pointerEvent) => {
+        if (!isDraggingPicker) return;
+        updateCustomColorPickerFromWheelEvent(pointerEvent);
+      });
+
+      const stopDraggingPicker = (pointerEvent = null) => {
+        isDraggingPicker = false;
+        if (pointerEvent && activePointerId !== null && customColorPickerWheel.hasPointerCapture(pointerEvent.pointerId)) {
+          customColorPickerWheel.releasePointerCapture(pointerEvent.pointerId);
+        }
+        activePointerId = null;
+      };
+
+      customColorPickerWheel.addEventListener('pointerup', stopDraggingPicker);
+      customColorPickerWheel.addEventListener('pointercancel', stopDraggingPicker);
+      customColorPickerWheel.addEventListener('lostpointercapture', () => {
+        isDraggingPicker = false;
+        activePointerId = null;
+      });
+    }
+
+    customColorBrightnessInput?.addEventListener('input', (inputEvent) => {
+      pickerState.v = Number(inputEvent.target.value) / 100;
+      pickerState.color = this.hsvToHex(pickerState.h, pickerState.s, pickerState.v);
+      syncCustomColorPickerUi();
     });
 
     customColorHexInput?.addEventListener('input', (inputEvent) => {
       const normalizedHex = this.normalizeHexColorInput(inputEvent.target.value);
       if (normalizedHex) {
-        syncCustomColorDraft(normalizedHex);
+        const hsv = this.hexToHsv(normalizedHex);
+        pickerState.h = hsv.h;
+        pickerState.s = hsv.s;
+        pickerState.v = hsv.v;
+        pickerState.color = normalizedHex;
+        syncCustomColorPickerUi();
       }
     });
 
-    this.getRootElementById('apply-custom-color-btn')?.addEventListener('click', () => {
+    customColorHexInput?.addEventListener('change', (inputEvent) => {
+      const normalizedHex = this.normalizeHexColorInput(inputEvent.target.value);
+      if (normalizedHex) {
+        const hsv = this.hexToHsv(normalizedHex);
+        pickerState.h = hsv.h;
+        pickerState.s = hsv.s;
+        pickerState.v = hsv.v;
+        pickerState.color = normalizedHex;
+        syncCustomColorDraft(normalizedHex);
+        syncCustomColorPickerUi();
+      }
+    });
+
+    this.getRootElementById('apply-custom-color-btn')?.addEventListener('click', async () => {
       const normalizedHex = this.normalizeHexColorInput(customColorHexInput?.value);
       if (!normalizedHex) {
         showCustomColorError(this.t('invalidHexColor'));
         return;
       }
-      applyCustomColorSelection(normalizedHex);
+      await applyCustomColorSelection(normalizedHex);
     });
 
-    this.getRootElementById('clear-custom-color-btn')?.addEventListener('click', () => {
-      if (!this.clearStoredCustomColor(event)) {
+    this.getRootElementById('clear-custom-color-btn')?.addEventListener('click', async () => {
+      await persistQueuedRecentCustomColors();
+      if (!await this.clearStoredCustomColor(event)) {
         closeCustomColorModal();
         return;
       }
       completeCustomColorChange();
     });
+
+    syncCustomColorPickerUi();
   }
 
 
@@ -9357,7 +10210,7 @@ class SkylightCalendarCard extends HTMLElement {
 
             if (!targetIsRecurring) {
               await this.deleteEvent(targetEvent.entityId, targetEvent.uid);
-              this.clearStoredCustomColor(targetEvent);
+              await this.clearStoredCustomColor(targetEvent);
               continue;
             }
 
@@ -9370,7 +10223,7 @@ class SkylightCalendarCard extends HTMLElement {
             } else if (selectedOption === 'all') {
               // Delete entire series
               await this.deleteEvent(targetEvent.entityId, targetEvent.uid);
-              this.clearStoredCustomColor(targetEvent);
+              await this.clearStoredCustomColor(targetEvent);
             } else {
               // Fallback for recurring targets without recurrence_id
               await this.deleteEvent(targetEvent.entityId, targetEvent.uid);
@@ -9380,7 +10233,7 @@ class SkylightCalendarCard extends HTMLElement {
           for (const targetEvent of deleteTargets) {
             // Delete single event
             await this.deleteEvent(targetEvent.entityId, targetEvent.uid);
-            this.clearStoredCustomColor(targetEvent);
+            await this.clearStoredCustomColor(targetEvent);
           }
         }
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -528,9 +528,13 @@ class SkylightCalendarCard extends HTMLElement {
     this._recentCustomColors = []; // Track recently used custom colors
     this._resolvedPreferenceStorageKey = null; // Track the resolved storage slot across card reconfiguration
     this._sharedPreferenceSyncInFlight = null; // Track dashboard-backed preference persistence
-    this._sharedPreferenceSaveTimer = null; // Debounce shared preference writes so UI updates can stay optimistic
+    this._sharedPreferenceSaveTimer = null; // Delay shared preference writes until the UI is idle enough to tolerate a dashboard save
     this._queuedSharedPreferenceState = null; // Track the latest shared preference payload waiting to be saved
-    this._sharedPreferenceSaveDebounceMs = 1200; // Delay shared writes enough to keep local interactions effectively instant
+    this._sharedPreferenceSaveDebounceMs = 1200; // Keep a short minimum delay before any shared save attempt
+    this._sharedPreferenceIdleDelayMs = 4000; // Give desktop/browser clients a brief idle window before triggering dashboard rewrites
+    this._sharedPreferenceTabletIdleDelayMs = 30000; // Give tablet/webview clients a much larger idle window before triggering dashboard rewrites
+    this._sharedPreferenceModalRetryDelayMs = 1000; // Retry shared saves periodically while modal flows are still active
+    this._lastSharedPreferenceInteractionAt = Date.now(); // Track the latest user interaction so shared saves can wait for idle time
     this._pendingSharedPreferenceCardKey = null; // Track the shared card key for unsaved optimistic preference overlays
     this._pendingSharedCustomEventColors = null; // Track unsaved shared custom event colors shown immediately in the UI
     this._pendingSharedCustomEventColorMeta = null; // Track unsaved shared custom color metadata shown immediately in the UI
@@ -593,6 +597,24 @@ class SkylightCalendarCard extends HTMLElement {
 
       this.updateCompactHeaderWrapState();
       this.updateCalendarBadgesScrollState();
+    };
+    this._handleSharedPreferenceInteraction = () => {
+      this.markSharedPreferenceInteraction();
+    };
+    this._handleSharedPreferenceVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        if (this._queuedSharedPreferenceState) {
+          void this.flushQueuedSharedPreferenceSave({ force: true });
+        }
+        return;
+      }
+
+      this.markSharedPreferenceInteraction();
+    };
+    this._handleSharedPreferencePageHide = () => {
+      if (this._queuedSharedPreferenceState) {
+        void this.flushQueuedSharedPreferenceSave({ force: true });
+      }
     };
   }
 
@@ -660,6 +682,80 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     return baseKey ? `${this.getPreferenceStoragePrefix()}${baseKey}` : null;
+  }
+
+  isTabletLikeSharedPreferenceClient() {
+    try {
+      if (navigator.maxTouchPoints > 0) {
+        return true;
+      }
+
+      return !!window.matchMedia?.('(pointer: coarse)').matches;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  getSharedPreferenceIdleDelayMs() {
+    return this.isTabletLikeSharedPreferenceClient()
+      ? this._sharedPreferenceTabletIdleDelayMs
+      : this._sharedPreferenceIdleDelayMs;
+  }
+
+  markSharedPreferenceInteraction(timestamp = Date.now()) {
+    this._lastSharedPreferenceInteractionAt = Number.isFinite(timestamp) ? timestamp : Date.now();
+  }
+
+  getRemainingSharedPreferenceIdleMs() {
+    const idleDelayMs = this.getSharedPreferenceIdleDelayMs();
+    if (!(idleDelayMs > 0)) {
+      return 0;
+    }
+
+    const elapsedMs = Date.now() - this._lastSharedPreferenceInteractionAt;
+    return Math.max(0, idleDelayMs - elapsedMs);
+  }
+
+  shouldDeferSharedPreferenceSave({ force = false } = {}) {
+    if (force) {
+      return false;
+    }
+
+    if (this.isEventManagementDialogOpen()) {
+      return true;
+    }
+
+    return this.getRemainingSharedPreferenceIdleMs() > 0;
+  }
+
+  getSharedPreferenceSaveDelayMs({ force = false } = {}) {
+    if (force) {
+      return 0;
+    }
+
+    return Math.max(
+      this._sharedPreferenceSaveDebounceMs,
+      this.isEventManagementDialogOpen() ? this._sharedPreferenceModalRetryDelayMs : 0,
+      this.getRemainingSharedPreferenceIdleMs()
+    );
+  }
+
+  scheduleSharedPreferenceSave({ force = false } = {}) {
+    if (!this._queuedSharedPreferenceState) {
+      return false;
+    }
+
+    if (this._sharedPreferenceSaveTimer) {
+      clearTimeout(this._sharedPreferenceSaveTimer);
+    }
+
+    const delayMs = this.getSharedPreferenceSaveDelayMs({ force });
+    this._sharedPreferenceSaveTimer = setTimeout(() => {
+      this._sharedPreferenceSaveTimer = null;
+      void this.flushQueuedSharedPreferenceSave({ force });
+    }, delayMs);
+
+    return true;
   }
 
   readPersistedPreferencesPayload(storageKey) {
@@ -2594,21 +2690,17 @@ class SkylightCalendarCard extends HTMLElement {
       sharedRecentCustomColors: this.normalizePreferenceColorList(sharedPreferenceState.sharedRecentCustomColors || [])
     };
 
-    if (this._sharedPreferenceSaveTimer) {
-      clearTimeout(this._sharedPreferenceSaveTimer);
-    }
-
-    this._sharedPreferenceSaveTimer = setTimeout(() => {
-      this._sharedPreferenceSaveTimer = null;
-      void this.flushQueuedSharedPreferenceSave();
-    }, this._sharedPreferenceSaveDebounceMs);
-
-    return true;
+    return this.scheduleSharedPreferenceSave();
   }
 
-  async flushQueuedSharedPreferenceSave() {
+  async flushQueuedSharedPreferenceSave({ force = false } = {}) {
     if (!this._hass?.callWS) {
       return false;
+    }
+
+    if (this._sharedPreferenceSaveTimer) {
+      clearTimeout(this._sharedPreferenceSaveTimer);
+      this._sharedPreferenceSaveTimer = null;
     }
 
     if (this._sharedPreferenceSyncInFlight) {
@@ -2617,6 +2709,11 @@ class SkylightCalendarCard extends HTMLElement {
       } catch (error) {
         // The current save path already logs failures; continue and retry the latest queued state.
       }
+    }
+
+    if (this.shouldDeferSharedPreferenceSave({ force })) {
+      this.scheduleSharedPreferenceSave({ force });
+      return false;
     }
 
     const queuedState = this._queuedSharedPreferenceState;
@@ -2632,7 +2729,7 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     if (this._queuedSharedPreferenceState) {
-      this.queueSharedPreferenceSave(this._queuedSharedPreferenceState);
+      this.scheduleSharedPreferenceSave();
     }
 
     return saveSucceeded;
@@ -3270,6 +3367,11 @@ class SkylightCalendarCard extends HTMLElement {
   connectedCallback() {
     window.addEventListener('resize', this._handleViewportResize);
     window.visualViewport?.addEventListener('resize', this._handleViewportResize);
+    window.addEventListener('pointerdown', this._handleSharedPreferenceInteraction, { passive: true });
+    window.addEventListener('touchstart', this._handleSharedPreferenceInteraction, { passive: true });
+    window.addEventListener('keydown', this._handleSharedPreferenceInteraction);
+    window.addEventListener('pagehide', this._handleSharedPreferencePageHide);
+    document.addEventListener('visibilitychange', this._handleSharedPreferenceVisibilityChange);
     this.attachSystemThemeListener();
     this.render();
   }
@@ -3277,6 +3379,11 @@ class SkylightCalendarCard extends HTMLElement {
   disconnectedCallback() {
     window.removeEventListener('resize', this._handleViewportResize);
     window.visualViewport?.removeEventListener('resize', this._handleViewportResize);
+    window.removeEventListener('pointerdown', this._handleSharedPreferenceInteraction);
+    window.removeEventListener('touchstart', this._handleSharedPreferenceInteraction);
+    window.removeEventListener('keydown', this._handleSharedPreferenceInteraction);
+    window.removeEventListener('pagehide', this._handleSharedPreferencePageHide);
+    document.removeEventListener('visibilitychange', this._handleSharedPreferenceVisibilityChange);
     this.detachSystemThemeListener();
     this.teardownWeatherForecastSubscription();
     if (this._modalVisibilityObserver) {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -533,8 +533,10 @@ class SkylightCalendarCard extends HTMLElement {
     this._sharedPreferenceSaveDebounceMs = 1200; // Delay shared writes enough to keep local interactions effectively instant
     this._pendingSharedPreferenceCardKey = null; // Track the shared card key for unsaved optimistic preference overlays
     this._pendingSharedCustomEventColors = null; // Track unsaved shared custom event colors shown immediately in the UI
+    this._pendingSharedCustomEventColorMeta = null; // Track unsaved shared custom color metadata shown immediately in the UI
     this._pendingSharedRecentCustomColors = null; // Track unsaved shared recent colors shown immediately in the UI
     this._sharedPreferenceMigrationAttempted = false; // Avoid repeated shared preference migration attempts
+    this._sharedPreferenceGarbageCollectionAttempted = false; // Avoid repeated shared preference cleanup attempts per config load
     this._frontendUserDataLoadInFlight = null; // Track per-user shared preference loads
     this._sharedUserDataCustomEventColors = {}; // Track per-user shared custom colors synced via HA frontend user data
     this._sharedUserDataRecentCustomColors = []; // Track per-user shared recent colors synced via HA frontend user data
@@ -642,7 +644,8 @@ class SkylightCalendarCard extends HTMLElement {
       return null;
     }
 
-    return baseKey;
+    const currentViewPath = this.getCurrentDashboardViewPath();
+    return currentViewPath ? `${currentViewPath}|${baseKey}` : baseKey;
   }
 
   getPreferenceStorageKey() {
@@ -789,6 +792,12 @@ class SkylightCalendarCard extends HTMLElement {
 
   getConfiguredDashboardPath() {
     return this.normalizeDashboardPath(this._config?.header_dashboard_path);
+  }
+
+  normalizeViewPathSegment(pathValue) {
+    if (typeof pathValue !== 'string') return null;
+    const trimmedPath = pathValue.trim().replace(/^\/+/, '').replace(/\/+$/, '');
+    return trimmedPath || null;
   }
 
   shouldShowDashboardNavButton() {
@@ -1052,6 +1061,10 @@ class SkylightCalendarCard extends HTMLElement {
     const normalizedHeaderColor = this.normalizeSingleColor(config.header_color);
     const normalizedHeaderTextColor = this.normalizeSingleColor(config.header_text_color);
     const normalizedSharedCustomEventColors = this.normalizePreferenceColorMap(config.shared_custom_event_colors || {});
+    const normalizedSharedCustomEventColorMeta = this.normalizePreferenceColorMetaMap(
+      config.shared_custom_event_color_meta || {},
+      normalizedSharedCustomEventColors
+    );
     const normalizedSharedRecentCustomColors = this.normalizePreferenceColorList(config.shared_recent_custom_colors || []);
     const hasConfiguredHeaderBackgroundOpacity = config.header_background_opacity !== undefined && config.header_background_opacity !== null && config.header_background_opacity !== '';
     const normalizedHeaderBackgroundOpacity = hasConfiguredHeaderBackgroundOpacity
@@ -1121,7 +1134,9 @@ class SkylightCalendarCard extends HTMLElement {
       event_font_colors: normalizedEventFontColors, // Per-calendar font colors for event bubble text
       event_styles: normalizedEventStyles, // Per-event styling rules with match logic
       day_styles: normalizedDayStyles, // Per-day styling rules
+      enable_custom_event_colors: config.enable_custom_event_colors !== false, // Enable local/shared custom event colors
       shared_custom_event_colors: normalizedSharedCustomEventColors, // Dashboard-shared custom event colors
+      shared_custom_event_color_meta: normalizedSharedCustomEventColorMeta, // Dashboard-shared custom color metadata used for pruning
       shared_recent_custom_colors: normalizedSharedRecentCustomColors, // Dashboard-shared recent custom colors
       hide_times_for_calendars: config.hide_times_for_calendars || [], // Hide times in schedule view for specific calendars
       show_current_time_bar: config.show_current_time_bar || false, // Show a "now" indicator in schedule view
@@ -1163,14 +1178,25 @@ class SkylightCalendarCard extends HTMLElement {
         : null,
       event_styles: normalizedEventStyles,
       day_styles: normalizedDayStyles,
+      enable_custom_event_colors: config.enable_custom_event_colors !== false,
       shared_custom_event_colors: normalizedSharedCustomEventColors,
+      shared_custom_event_color_meta: normalizedSharedCustomEventColorMeta,
       shared_recent_custom_colors: normalizedSharedRecentCustomColors
     };
     this._resolvedPreferenceStorageKey = this._config.preference_storage_key
       ? null
       : previousResolvedPreferenceStorageKey;
     this._sharedPreferenceMigrationAttempted = false;
+    this._sharedPreferenceGarbageCollectionAttempted = false;
     this._viewMode = this._config.default_view;
+    if (!this._config.enable_custom_event_colors) {
+      if (this._sharedPreferenceSaveTimer) {
+        clearTimeout(this._sharedPreferenceSaveTimer);
+        this._sharedPreferenceSaveTimer = null;
+      }
+      this._queuedSharedPreferenceState = null;
+      this.clearPendingSharedPreferenceOverlay();
+    }
     this.applyThemeMode(this._config.color_scheme);
     this._hiddenCalendars = new Set(
       Array.from(previousHiddenCalendars).filter((entityId) => this._config.entities.includes(entityId))
@@ -1245,6 +1271,7 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     this.maybePromoteLocalPreferencesToShared();
+    this.maybeGarbageCollectSharedPreferences();
     this.ensureWeatherForecastSubscription();
     this.refreshWeatherForecastData();
 
@@ -1317,6 +1344,27 @@ class SkylightCalendarCard extends HTMLElement {
       .filter((color) => typeof color === 'string' && !!color)
       .filter((color, index, array) => array.indexOf(color) === index)
       .slice(0, 12);
+  }
+
+  normalizePreferenceColorMetaMap(metaMap, colorMap = null) {
+    if (!metaMap || typeof metaMap !== 'object' || Array.isArray(metaMap)) return {};
+
+    const allowedKeys = colorMap && typeof colorMap === 'object' && !Array.isArray(colorMap)
+      ? new Set(Object.keys(colorMap))
+      : null;
+
+    return Object.entries(metaMap).reduce((acc, [storageKey, touchedAt]) => {
+      const normalizedKey = String(storageKey || '').trim();
+      const normalizedTouchedAt = Math.floor(Number(touchedAt));
+      if (!normalizedKey || !Number.isFinite(normalizedTouchedAt) || normalizedTouchedAt <= 0) {
+        return acc;
+      }
+      if (allowedKeys && !allowedKeys.has(normalizedKey)) {
+        return acc;
+      }
+      acc[normalizedKey] = normalizedTouchedAt;
+      return acc;
+    }, {});
   }
 
   normalizeSingleColor(colorValue) {
@@ -1893,7 +1941,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getStoredCustomColor(event) {
-    if (!event) return null;
+    if (!this.isCustomEventColorFeatureEnabled() || !event) return null;
 
     const seriesKey = this.getCustomColorSeriesKey(event);
     const sharedCustomEventColors = this.getEffectiveSharedCustomEventColors();
@@ -2063,6 +2111,10 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getRecentCustomColors() {
+    if (!this.isCustomEventColorFeatureEnabled()) {
+      return [];
+    }
+
     const sharedRecentColors = this.getEffectiveSharedRecentCustomColors();
     if (sharedRecentColors.length > 0) {
       return sharedRecentColors;
@@ -2100,6 +2152,10 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   async saveRecentCustomColors(recentCustomColors) {
+    if (!this.isCustomEventColorFeatureEnabled()) {
+      return false;
+    }
+
     const normalizedRecentCustomColors = this.normalizePreferenceColorList(recentCustomColors || []);
     const currentRecentCustomColors = this.getRecentCustomColors();
     const isUnchanged = normalizedRecentCustomColors.length === currentRecentCustomColors.length &&
@@ -2113,6 +2169,7 @@ class SkylightCalendarCard extends HTMLElement {
     this.persistPreferences();
     const optimisticSharedState = this.getOptimisticSharedPreferenceState({
       sharedCustomEventColors: this.getEffectiveSharedCustomEventColors(),
+      sharedCustomEventColorMeta: this.getEffectiveSharedCustomEventColorMeta(),
       sharedRecentCustomColors: normalizedRecentCustomColors
     });
     this.queueSharedPreferenceSave(optimisticSharedState);
@@ -2159,6 +2216,24 @@ class SkylightCalendarCard extends HTMLElement {
     return `skylight-shared-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
   }
 
+  isCustomEventColorFeatureEnabled() {
+    return this._config?.enable_custom_event_colors !== false;
+  }
+
+  getSharedCustomColorEntryLimit() {
+    return 250;
+  }
+
+  getSharedCustomColorRetentionMs() {
+    return 180 * 24 * 60 * 60 * 1000;
+  }
+
+  extractEntityIdFromPreferenceStorageKey(storageKey) {
+    const parts = String(storageKey || '').split('|');
+    const entityId = parts[1];
+    return typeof entityId === 'string' && entityId.startsWith('calendar.') ? entityId : null;
+  }
+
   getCurrentDashboardRoutePath() {
     const pathname = String(window.location?.pathname || '').split('?')[0].split('#')[0];
     if (pathname && pathname !== '/') {
@@ -2192,6 +2267,23 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     return this.getDashboardScopeKey();
+  }
+
+  getCurrentDashboardViewPath() {
+    const routePath = this.getCurrentDashboardRoutePath();
+    const dashboardUrlPath = this.getDashboardConfigUrlPath();
+    const dashboardPrefix = dashboardUrlPath ? `/${dashboardUrlPath}` : '';
+
+    if (!dashboardPrefix || routePath === dashboardPrefix || routePath === `${dashboardPrefix}/`) {
+      return null;
+    }
+
+    if (!routePath.startsWith(`${dashboardPrefix}/`)) {
+      return null;
+    }
+
+    const remainingPath = routePath.slice(dashboardPrefix.length + 1);
+    return this.normalizeViewPathSegment(remainingPath.split('/')[0]);
   }
 
   cloneConfigValue(value) {
@@ -2229,6 +2321,19 @@ class SkylightCalendarCard extends HTMLElement {
     return currentEntities && currentEntities === candidateEntities && currentTitle === candidateTitle;
   }
 
+  getCurrentDashboardViewCandidates(views) {
+    if (!Array.isArray(views) || views.length === 0) {
+      return [];
+    }
+
+    const currentViewPath = this.getCurrentDashboardViewPath();
+    if (currentViewPath) {
+      return views.filter((view) => this.normalizeViewPathSegment(view?.path) === currentViewPath);
+    }
+
+    return [views[0], ...views.slice(1).filter((view) => this.normalizeViewPathSegment(view?.path) === null)];
+  }
+
   findSharedPreferenceCardInDashboardConfig(lovelaceConfig) {
     const searchCards = (cards) => {
       if (!Array.isArray(cards)) return null;
@@ -2253,26 +2358,41 @@ class SkylightCalendarCard extends HTMLElement {
       return null;
     };
 
-    const views = Array.isArray(lovelaceConfig?.views) ? lovelaceConfig.views : [];
-    for (const view of views) {
-      const directMatch = searchCards(view?.cards);
-      if (directMatch) return directMatch;
+    const searchViews = (viewsToSearch) => {
+      for (const view of viewsToSearch) {
+        const directMatch = searchCards(view?.cards);
+        if (directMatch) return directMatch;
 
-      if (Array.isArray(view?.sections)) {
-        for (const section of view.sections) {
-          const sectionMatch = searchCards(section?.cards);
-          if (sectionMatch) return sectionMatch;
+        if (Array.isArray(view?.sections)) {
+          for (const section of view.sections) {
+            const sectionMatch = searchCards(section?.cards);
+            if (sectionMatch) return sectionMatch;
+          }
         }
       }
+
+      return null;
+    };
+
+    const views = Array.isArray(lovelaceConfig?.views) ? lovelaceConfig.views : [];
+    const candidateViews = this.getCurrentDashboardViewCandidates(views);
+    const candidateMatch = searchViews(candidateViews);
+    if (candidateMatch) {
+      return candidateMatch;
+    }
+
+    if (this.getSharedPreferenceCardKey()) {
+      return searchViews(views);
     }
 
     return null;
   }
 
-  applySharedPreferenceStateToConfig(sharedCustomEventColors, sharedRecentCustomColors, sharedCardKey = null) {
+  applySharedPreferenceStateToConfig(sharedCustomEventColors, sharedRecentCustomColors, sharedCustomEventColorMeta = {}, sharedCardKey = null) {
     this._config = {
       ...this._config,
       shared_custom_event_colors: this.normalizePreferenceColorMap(sharedCustomEventColors || {}),
+      shared_custom_event_color_meta: this.normalizePreferenceColorMetaMap(sharedCustomEventColorMeta || {}, sharedCustomEventColors || {}),
       shared_recent_custom_colors: this.normalizePreferenceColorList(sharedRecentCustomColors || []),
       ...(sharedCardKey ? { _shared_config_key: sharedCardKey } : {})
     };
@@ -2286,6 +2406,14 @@ class SkylightCalendarCard extends HTMLElement {
     return this.normalizePreferenceColorMap(this._config?.shared_custom_event_colors || {});
   }
 
+  getEffectiveSharedCustomEventColorMeta() {
+    if (this._pendingSharedCustomEventColorMeta !== null) {
+      return this.normalizePreferenceColorMetaMap(this._pendingSharedCustomEventColorMeta, this.getEffectiveSharedCustomEventColors());
+    }
+
+    return this.normalizePreferenceColorMetaMap(this._config?.shared_custom_event_color_meta || {}, this.getEffectiveSharedCustomEventColors());
+  }
+
   getEffectiveSharedRecentCustomColors() {
     if (this._pendingSharedRecentCustomColors !== null) {
       return this.normalizePreferenceColorList(this._pendingSharedRecentCustomColors);
@@ -2294,35 +2422,128 @@ class SkylightCalendarCard extends HTMLElement {
     return this.normalizePreferenceColorList(this._config?.shared_recent_custom_colors || []);
   }
 
+  prepareSharedPreferenceState({ sharedCustomEventColors, sharedRecentCustomColors, sharedCustomEventColorMeta = {}, touchedKeys = [] }) {
+    const now = Date.now();
+    const normalizedSharedCustomEventColors = this.normalizePreferenceColorMap(sharedCustomEventColors || {});
+    const normalizedSharedRecentCustomColors = this.normalizePreferenceColorList(sharedRecentCustomColors || []);
+    const normalizedSharedCustomEventColorMeta = this.normalizePreferenceColorMetaMap(
+      sharedCustomEventColorMeta || {},
+      normalizedSharedCustomEventColors
+    );
+
+    Object.keys(normalizedSharedCustomEventColors).forEach((storageKey) => {
+      if (!normalizedSharedCustomEventColorMeta[storageKey]) {
+        normalizedSharedCustomEventColorMeta[storageKey] = now;
+      }
+    });
+
+    touchedKeys
+      .map((storageKey) => String(storageKey || '').trim())
+      .filter(Boolean)
+      .forEach((storageKey) => {
+        if (normalizedSharedCustomEventColors[storageKey]) {
+          normalizedSharedCustomEventColorMeta[storageKey] = now;
+        }
+      });
+
+    const configuredEntities = new Set(
+      Array.isArray(this._config?.entities)
+        ? this._config.entities.filter((entityId) => typeof entityId === 'string' && entityId.startsWith('calendar.'))
+        : []
+    );
+
+    Object.keys(normalizedSharedCustomEventColors).forEach((storageKey) => {
+      const entityId = this.extractEntityIdFromPreferenceStorageKey(storageKey);
+      if (!entityId || !configuredEntities.has(entityId)) {
+        delete normalizedSharedCustomEventColors[storageKey];
+        delete normalizedSharedCustomEventColorMeta[storageKey];
+      }
+    });
+
+    const retentionMs = this.getSharedCustomColorRetentionMs();
+    Object.keys(normalizedSharedCustomEventColors).forEach((storageKey) => {
+      const touchedAt = normalizedSharedCustomEventColorMeta[storageKey];
+      if (Number.isFinite(touchedAt) && touchedAt > 0 && (now - touchedAt) > retentionMs) {
+        delete normalizedSharedCustomEventColors[storageKey];
+        delete normalizedSharedCustomEventColorMeta[storageKey];
+      }
+    });
+
+    const maxEntries = this.getSharedCustomColorEntryLimit();
+    const sortedKeys = Object.keys(normalizedSharedCustomEventColors)
+      .sort((leftKey, rightKey) => {
+        const leftTouchedAt = normalizedSharedCustomEventColorMeta[leftKey] || 0;
+        const rightTouchedAt = normalizedSharedCustomEventColorMeta[rightKey] || 0;
+        if (rightTouchedAt !== leftTouchedAt) {
+          return rightTouchedAt - leftTouchedAt;
+        }
+        return leftKey.localeCompare(rightKey);
+      });
+
+    if (sortedKeys.length > maxEntries) {
+      const allowedKeys = new Set(sortedKeys.slice(0, maxEntries));
+      Object.keys(normalizedSharedCustomEventColors).forEach((storageKey) => {
+        if (!allowedKeys.has(storageKey)) {
+          delete normalizedSharedCustomEventColors[storageKey];
+          delete normalizedSharedCustomEventColorMeta[storageKey];
+        }
+      });
+    }
+
+    return {
+      sharedCustomEventColors: normalizedSharedCustomEventColors,
+      sharedRecentCustomColors: normalizedSharedRecentCustomColors,
+      sharedCustomEventColorMeta: this.normalizePreferenceColorMetaMap(
+        normalizedSharedCustomEventColorMeta,
+        normalizedSharedCustomEventColors
+      )
+    };
+  }
+
+  sharedPreferenceStatesEqual(leftState, rightState) {
+    if (!leftState || !rightState) {
+      return false;
+    }
+
+    if ((leftState.sharedCardKey || null) !== (rightState.sharedCardKey || null)) {
+      return false;
+    }
+
+    const leftCustomEventColors = this.normalizePreferenceColorMap(leftState.sharedCustomEventColors || {});
+    const rightCustomEventColors = this.normalizePreferenceColorMap(rightState.sharedCustomEventColors || {});
+    const leftRecentCustomColors = this.normalizePreferenceColorList(leftState.sharedRecentCustomColors || []);
+    const rightRecentCustomColors = this.normalizePreferenceColorList(rightState.sharedRecentCustomColors || []);
+    const leftCustomEventColorMeta = this.normalizePreferenceColorMetaMap(leftState.sharedCustomEventColorMeta || {}, leftCustomEventColors);
+    const rightCustomEventColorMeta = this.normalizePreferenceColorMetaMap(rightState.sharedCustomEventColorMeta || {}, rightCustomEventColors);
+
+    const leftColorKeys = Object.keys(leftCustomEventColors).sort();
+    const rightColorKeys = Object.keys(rightCustomEventColors).sort();
+    if (leftColorKeys.length !== rightColorKeys.length) {
+      return false;
+    }
+
+    if (!leftColorKeys.every((key, index) => (
+      key === rightColorKeys[index] &&
+      leftCustomEventColors[key] === rightCustomEventColors[key] &&
+      (leftCustomEventColorMeta[key] || 0) === (rightCustomEventColorMeta[key] || 0)
+    ))) {
+      return false;
+    }
+
+    if (leftRecentCustomColors.length !== rightRecentCustomColors.length) {
+      return false;
+    }
+
+    return leftRecentCustomColors.every((entry, index) => entry === rightRecentCustomColors[index]);
+  }
+
   sharedPreferencePayloadMatchesPending(sharedPreferenceState) {
-    if (!sharedPreferenceState) {
-      return false;
-    }
-
-    const normalizedPendingCustomEventColors = this.normalizePreferenceColorMap(this._pendingSharedCustomEventColors || {});
-    const normalizedPendingRecentCustomColors = this.normalizePreferenceColorList(this._pendingSharedRecentCustomColors || []);
-    const normalizedSharedCustomEventColors = this.normalizePreferenceColorMap(sharedPreferenceState.sharedCustomEventColors || {});
-    const normalizedSharedRecentCustomColors = this.normalizePreferenceColorList(sharedPreferenceState.sharedRecentCustomColors || []);
-    const pendingCustomKeys = Object.keys(normalizedPendingCustomEventColors).sort();
-    const sharedCustomKeys = Object.keys(normalizedSharedCustomEventColors).sort();
-
-    if ((this._pendingSharedPreferenceCardKey || null) !== (sharedPreferenceState.sharedCardKey || null)) {
-      return false;
-    }
-
-    if (pendingCustomKeys.length !== sharedCustomKeys.length) {
-      return false;
-    }
-
-    if (!pendingCustomKeys.every((key, index) => key === sharedCustomKeys[index] && normalizedPendingCustomEventColors[key] === normalizedSharedCustomEventColors[key])) {
-      return false;
-    }
-
-    if (normalizedPendingRecentCustomColors.length !== normalizedSharedRecentCustomColors.length) {
-      return false;
-    }
-
-    return normalizedPendingRecentCustomColors.every((entry, index) => entry === normalizedSharedRecentCustomColors[index]);
+    return this.sharedPreferenceStatesEqual({
+      sharedCardKey: this._pendingSharedPreferenceCardKey,
+      sharedCustomEventColors: this._pendingSharedCustomEventColors,
+      sharedCustomEventColorMeta: this._pendingSharedCustomEventColorMeta,
+      sharedRecentCustomColors: this._pendingSharedRecentCustomColors
+    }, sharedPreferenceState);
   }
 
   clearPendingSharedPreferenceOverlay(sharedPreferenceState = null) {
@@ -2332,22 +2553,29 @@ class SkylightCalendarCard extends HTMLElement {
 
     this._pendingSharedPreferenceCardKey = null;
     this._pendingSharedCustomEventColors = null;
+    this._pendingSharedCustomEventColorMeta = null;
     this._pendingSharedRecentCustomColors = null;
   }
 
-  getOptimisticSharedPreferenceState({ sharedCustomEventColors, sharedRecentCustomColors }) {
+  getOptimisticSharedPreferenceState({ sharedCustomEventColors, sharedRecentCustomColors, sharedCustomEventColorMeta = {}, touchedKeys = [] }) {
     const sharedCardKey = this._pendingSharedPreferenceCardKey || this.getSharedPreferenceCardKey() || this.createSharedPreferenceCardKey();
-    const normalizedSharedCustomEventColors = this.normalizePreferenceColorMap(sharedCustomEventColors || {});
-    const normalizedSharedRecentCustomColors = this.normalizePreferenceColorList(sharedRecentCustomColors || []);
+    const preparedSharedState = this.prepareSharedPreferenceState({
+      sharedCustomEventColors,
+      sharedRecentCustomColors,
+      sharedCustomEventColorMeta,
+      touchedKeys
+    });
 
     this._pendingSharedPreferenceCardKey = sharedCardKey;
-    this._pendingSharedCustomEventColors = normalizedSharedCustomEventColors;
-    this._pendingSharedRecentCustomColors = normalizedSharedRecentCustomColors;
+    this._pendingSharedCustomEventColors = preparedSharedState.sharedCustomEventColors;
+    this._pendingSharedCustomEventColorMeta = preparedSharedState.sharedCustomEventColorMeta;
+    this._pendingSharedRecentCustomColors = preparedSharedState.sharedRecentCustomColors;
 
     return {
       sharedCardKey,
-      sharedCustomEventColors: normalizedSharedCustomEventColors,
-      sharedRecentCustomColors: normalizedSharedRecentCustomColors
+      sharedCustomEventColors: preparedSharedState.sharedCustomEventColors,
+      sharedCustomEventColorMeta: preparedSharedState.sharedCustomEventColorMeta,
+      sharedRecentCustomColors: preparedSharedState.sharedRecentCustomColors
     };
   }
 
@@ -2359,6 +2587,10 @@ class SkylightCalendarCard extends HTMLElement {
     this._queuedSharedPreferenceState = {
       sharedCardKey: sharedPreferenceState.sharedCardKey || this.getSharedPreferenceCardKey() || this.createSharedPreferenceCardKey(),
       sharedCustomEventColors: this.normalizePreferenceColorMap(sharedPreferenceState.sharedCustomEventColors || {}),
+      sharedCustomEventColorMeta: this.normalizePreferenceColorMetaMap(
+        sharedPreferenceState.sharedCustomEventColorMeta || {},
+        sharedPreferenceState.sharedCustomEventColors || {}
+      ),
       sharedRecentCustomColors: this.normalizePreferenceColorList(sharedPreferenceState.sharedRecentCustomColors || [])
     };
 
@@ -2406,14 +2638,20 @@ class SkylightCalendarCard extends HTMLElement {
     return saveSucceeded;
   }
 
-  async saveSharedPreferenceState({ sharedCustomEventColors, sharedRecentCustomColors, sharedCardKey = null }) {
+  async saveSharedPreferenceState({ sharedCustomEventColors, sharedRecentCustomColors, sharedCustomEventColorMeta = {}, sharedCardKey = null }) {
     if (!this._hass?.callWS || this._sharedPreferenceSyncInFlight) {
       return false;
     }
 
     const resolvedSharedCardKey = sharedCardKey || this.getSharedPreferenceCardKey() || this.createSharedPreferenceCardKey();
-    const normalizedSharedCustomEventColors = this.normalizePreferenceColorMap(sharedCustomEventColors || {});
-    const normalizedSharedRecentCustomColors = this.normalizePreferenceColorList(sharedRecentCustomColors || []);
+    const preparedSharedState = this.prepareSharedPreferenceState({
+      sharedCustomEventColors,
+      sharedRecentCustomColors,
+      sharedCustomEventColorMeta
+    });
+    const normalizedSharedCustomEventColors = preparedSharedState.sharedCustomEventColors;
+    const normalizedSharedCustomEventColorMeta = preparedSharedState.sharedCustomEventColorMeta;
+    const normalizedSharedRecentCustomColors = preparedSharedState.sharedRecentCustomColors;
     const dashboardUrlPath = this.getDashboardConfigUrlPath();
 
     const syncPromise = (async () => {
@@ -2432,10 +2670,33 @@ class SkylightCalendarCard extends HTMLElement {
           return false;
         }
 
+        const currentSharedState = {
+          sharedCardKey: typeof match.cardConfig?._shared_config_key === 'string' ? match.cardConfig._shared_config_key.trim() : null,
+          sharedCustomEventColors: match.cardConfig?.shared_custom_event_colors || {},
+          sharedCustomEventColorMeta: match.cardConfig?.shared_custom_event_color_meta || {},
+          sharedRecentCustomColors: match.cardConfig?.shared_recent_custom_colors || []
+        };
+        const nextSharedState = {
+          sharedCardKey: resolvedSharedCardKey,
+          sharedCustomEventColors: normalizedSharedCustomEventColors,
+          sharedCustomEventColorMeta: normalizedSharedCustomEventColorMeta,
+          sharedRecentCustomColors: normalizedSharedRecentCustomColors
+        };
+        if (this.sharedPreferenceStatesEqual(currentSharedState, nextSharedState)) {
+          this.applySharedPreferenceStateToConfig(
+            normalizedSharedCustomEventColors,
+            normalizedSharedRecentCustomColors,
+            normalizedSharedCustomEventColorMeta,
+            resolvedSharedCardKey
+          );
+          return true;
+        }
+
         const nextCardConfig = {
           ...match.cardConfig,
           _shared_config_key: resolvedSharedCardKey,
           shared_custom_event_colors: normalizedSharedCustomEventColors,
+          shared_custom_event_color_meta: normalizedSharedCustomEventColorMeta,
           shared_recent_custom_colors: normalizedSharedRecentCustomColors
         };
         match.parentArray[match.index] = nextCardConfig;
@@ -2446,7 +2707,12 @@ class SkylightCalendarCard extends HTMLElement {
           config: nextLovelaceConfig
         });
 
-        this.applySharedPreferenceStateToConfig(normalizedSharedCustomEventColors, normalizedSharedRecentCustomColors, resolvedSharedCardKey);
+        this.applySharedPreferenceStateToConfig(
+          normalizedSharedCustomEventColors,
+          normalizedSharedRecentCustomColors,
+          normalizedSharedCustomEventColorMeta,
+          resolvedSharedCardKey
+        );
         return true;
       } catch (error) {
         console.warn('Failed to save shared custom color preferences to dashboard config:', error);
@@ -2461,7 +2727,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   maybePromoteLocalPreferencesToShared() {
-    if (this._sharedPreferenceMigrationAttempted || !this._hass?.callWS) {
+    if (this._sharedPreferenceMigrationAttempted || !this._hass?.callWS || !this.isCustomEventColorFeatureEnabled()) {
       return;
     }
 
@@ -2478,12 +2744,43 @@ class SkylightCalendarCard extends HTMLElement {
 
     const optimisticSharedState = this.getOptimisticSharedPreferenceState({
       sharedCustomEventColors: this._customEventColors,
+      sharedCustomEventColorMeta: this.getEffectiveSharedCustomEventColorMeta(),
       sharedRecentCustomColors: this._recentCustomColors
     });
     this.queueSharedPreferenceSave(optimisticSharedState);
   }
 
+  maybeGarbageCollectSharedPreferences() {
+    if (this._sharedPreferenceGarbageCollectionAttempted || !this._hass?.callWS || !this.isCustomEventColorFeatureEnabled()) {
+      return;
+    }
+
+    this._sharedPreferenceGarbageCollectionAttempted = true;
+
+    const currentSharedState = {
+      sharedCardKey: this.getSharedPreferenceCardKey(),
+      sharedCustomEventColors: this.getEffectiveSharedCustomEventColors(),
+      sharedCustomEventColorMeta: this.getEffectiveSharedCustomEventColorMeta(),
+      sharedRecentCustomColors: this.getEffectiveSharedRecentCustomColors()
+    };
+    const preparedSharedState = this.prepareSharedPreferenceState(currentSharedState);
+
+    if (this.sharedPreferenceStatesEqual(currentSharedState, {
+      sharedCardKey: this.getSharedPreferenceCardKey(),
+      ...preparedSharedState
+    })) {
+      return;
+    }
+
+    const optimisticSharedState = this.getOptimisticSharedPreferenceState(preparedSharedState);
+    this.queueSharedPreferenceSave(optimisticSharedState);
+  }
+
   async setStoredCustomColor(event, color) {
+    if (!this.isCustomEventColorFeatureEnabled()) {
+      return false;
+    }
+
     const storageKey = this.getCustomColorSeriesKey(event) || this.getCustomColorEventKey(event);
     const normalizedColor = this.colorToHex(color) || this.normalizeSingleColor(color);
     if (!storageKey || !normalizedColor) {
@@ -2507,13 +2804,19 @@ class SkylightCalendarCard extends HTMLElement {
     this.persistPreferences();
     const optimisticSharedState = this.getOptimisticSharedPreferenceState({
       sharedCustomEventColors: nextSharedCustomEventColors,
-      sharedRecentCustomColors: nextRecentCustomColors
+      sharedCustomEventColorMeta: this.getEffectiveSharedCustomEventColorMeta(),
+      sharedRecentCustomColors: nextRecentCustomColors,
+      touchedKeys: [storageKey]
     });
     this.queueSharedPreferenceSave(optimisticSharedState);
     return true;
   }
 
   async clearStoredCustomColor(event) {
+    if (!this.isCustomEventColorFeatureEnabled()) {
+      return false;
+    }
+
     const candidateKeys = [
       this.getCustomColorSeriesKey(event),
       this.getCustomColorEventKey(event)
@@ -2524,11 +2827,13 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     const nextSharedCustomEventColors = { ...this.getEffectiveSharedCustomEventColors() };
+    const nextSharedCustomEventColorMeta = { ...this.getEffectiveSharedCustomEventColorMeta() };
     let sharedChanged = false;
 
     candidateKeys.forEach((key) => {
       if (Object.prototype.hasOwnProperty.call(nextSharedCustomEventColors, key)) {
         delete nextSharedCustomEventColors[key];
+        delete nextSharedCustomEventColorMeta[key];
         sharedChanged = true;
       }
     });
@@ -2545,6 +2850,7 @@ class SkylightCalendarCard extends HTMLElement {
       this.persistPreferences();
       const optimisticSharedState = this.getOptimisticSharedPreferenceState({
         sharedCustomEventColors: nextSharedCustomEventColors,
+        sharedCustomEventColorMeta: nextSharedCustomEventColorMeta,
         sharedRecentCustomColors: this.getRecentCustomColors()
       });
       this.queueSharedPreferenceSave(optimisticSharedState);
@@ -10318,7 +10624,7 @@ class SkylightCalendarCard extends HTMLElement {
     // WebSocket delete works for Google Calendar and other integrations
     const canEdit = canModify;
     const canDelete = canModify; // WebSocket delete works for all calendars including Google
-    const canCustomColor = true;
+    const canCustomColor = this.isCustomEventColorFeatureEnabled();
     const customColor = this.getStoredCustomColor(event);
     const customColorButtonColor = customColor || this.getEventBackgroundColor(event);
     const customColorButtonTextColor = this.getContractColor(customColorButtonColor);
@@ -10973,7 +11279,8 @@ class SkylightCalendarCard extends HTMLElement {
       header_dashboard_path: null,
       header_weather_sensor: '',
       color_scheme: 'auto',
-      enable_event_management: true
+      enable_event_management: true,
+      enable_custom_event_colors: true
     };
   }
 
@@ -11163,7 +11470,8 @@ class SkylightCalendarCardEditor extends HTMLElement {
       max_events: 0,
       first_day_of_week: 0,
       header_background_opacity: 0,
-      background_opacity: 0
+      background_opacity: 0,
+      enable_custom_event_colors: true
     };
     return Object.prototype.hasOwnProperty.call(defaults, key) ? defaults[key] : 0;
   }
@@ -11730,6 +12038,7 @@ class SkylightCalendarCardEditor extends HTMLElement {
         <label><input type="checkbox" data-field="use_24hr_schedule" ${this._config.use_24hr_schedule ? 'checked' : ''}> Use 24-hour schedule time</label>
         <label><input type="checkbox" data-field="show_event_location" ${this._config.show_event_location ? 'checked' : ''}> Show event location</label>
         <label><input type="checkbox" data-field="use_short_location" ${this._config.use_short_location ? 'checked' : ''}> Shorten event location in views</label>
+        <label><input type="checkbox" data-field="enable_custom_event_colors" ${this._config.enable_custom_event_colors !== false ? 'checked' : ''}> Enable custom event colors</label>
         <label><input type="checkbox" data-field="combine_calendars" ${this._config.combine_calendars ? 'checked' : ''}> Combine duplicate events across calendars</label>
       </div>
       ${this._config.combine_calendars ? `

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -56,6 +56,17 @@ const TRANSLATIONS = {
       createEvent: 'Create Event',
       creating: 'Creating...',
       editEvent: 'Edit Event',
+      customColor: 'Custom Color',
+      customColorTitle: 'Custom Event Color',
+      customColorEventHint: 'Choose a local-only color for this event.',
+      customColorSeriesHint: 'Choose a local-only color for this recurring series.',
+      clearCustomColor: 'Clear Custom Color',
+      recentColors: 'Recent Colors',
+      customColorInput: 'Custom Color',
+      hexColor: 'Hex Color',
+      applyCustomColor: 'Apply Color',
+      invalidHexColor: 'Enter a valid 6-digit hex color.',
+      usingDefaultColor: 'Using default styling',
       saveChanges: 'Save Changes',
       saving: 'Saving...',
       delete: 'Delete',
@@ -508,6 +519,9 @@ class SkylightCalendarCard extends HTMLElement {
     this._calendarDataSignatures = {}; // Track per-calendar data for change detection
     this._lastUnchangedDataRender = null; // Throttle unchanged-data UI refreshes
     this._hiddenCalendars = new Set(); // Track which calendars are hidden
+    this._customEventColors = {}; // Track local-only custom event colors
+    this._recentCustomColors = []; // Track recently used custom colors
+    this._resolvedPreferenceStorageKey = null; // Track the resolved storage slot across card reconfiguration
     this._calendarCapabilities = {}; // Track calendar capabilities
     this._activeLanguage = DEFAULT_LANGUAGE;
     this._hasCustomTitle = false;
@@ -591,15 +605,163 @@ class SkylightCalendarCard extends HTMLElement {
     return 'default';
   }
 
-  getPreferenceStorageKey() {
-    const dashboardScope = this.getDashboardScopeKey();
-    const baseKey = this._config.preference_storage_key || (this._config.entities || []).join('|');
+  getPreferenceStoragePrefix() {
+    return `skylight-calendar-card:${this.getDashboardScopeKey()}:`;
+  }
+
+  getConfiguredPreferenceStorageBaseKey() {
+    const configuredKey = typeof this._config?.preference_storage_key === 'string'
+      ? this._config.preference_storage_key.trim()
+      : '';
+    if (configuredKey) {
+      return configuredKey;
+    }
+
+    const entities = Array.isArray(this._config?.entities)
+      ? this._config.entities.filter((entityId) => typeof entityId === 'string' && entityId.trim())
+      : [];
+    const baseKey = entities.join('|');
 
     if (!baseKey) {
       return null;
     }
 
-    return `skylight-calendar-card:${dashboardScope}:${baseKey}`;
+    return baseKey;
+  }
+
+  getPreferenceStorageKey() {
+    const baseKey = this.getConfiguredPreferenceStorageBaseKey();
+
+    if (typeof this._config?.preference_storage_key === 'string' && this._config.preference_storage_key.trim()) {
+      return baseKey ? `${this.getPreferenceStoragePrefix()}${baseKey}` : null;
+    }
+
+    if (this._resolvedPreferenceStorageKey) {
+      return this._resolvedPreferenceStorageKey;
+    }
+
+    return baseKey ? `${this.getPreferenceStoragePrefix()}${baseKey}` : null;
+  }
+
+  readPersistedPreferencesPayload(storageKey) {
+    if (!storageKey) return null;
+
+    try {
+      const raw = window.localStorage?.getItem(storageKey);
+      if (!raw) return null;
+
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' ? parsed : null;
+    } catch (error) {
+      console.warn(`Failed to read persisted calendar preferences for ${storageKey}:`, error);
+      return null;
+    }
+  }
+
+  extractPersistedPreferenceEntityIds(parsed) {
+    const entityIds = new Set();
+
+    if (Array.isArray(parsed?.meta?.entities)) {
+      parsed.meta.entities
+        .filter((entityId) => typeof entityId === 'string' && entityId.startsWith('calendar.'))
+        .forEach((entityId) => entityIds.add(entityId));
+    }
+
+    if (Array.isArray(parsed?.hiddenCalendars)) {
+      parsed.hiddenCalendars
+        .filter((entityId) => typeof entityId === 'string' && entityId.startsWith('calendar.'))
+        .forEach((entityId) => entityIds.add(entityId));
+    }
+
+    if (parsed?.customEventColors && typeof parsed.customEventColors === 'object' && !Array.isArray(parsed.customEventColors)) {
+      Object.keys(parsed.customEventColors).forEach((storageKey) => {
+        const parts = String(storageKey || '').split('|');
+        const entityId = parts[1];
+        if (typeof entityId === 'string' && entityId.startsWith('calendar.')) {
+          entityIds.add(entityId);
+        }
+      });
+    }
+
+    return Array.from(entityIds);
+  }
+
+  isPersistedPreferencesEffectivelyEmpty(parsed) {
+    if (!parsed || typeof parsed !== 'object') {
+      return true;
+    }
+
+    const hiddenCount = Array.isArray(parsed.hiddenCalendars) ? parsed.hiddenCalendars.length : 0;
+    const recentCount = Array.isArray(parsed.recentCustomColors) ? parsed.recentCustomColors.length : 0;
+    const customColorCount = parsed.customEventColors && typeof parsed.customEventColors === 'object' && !Array.isArray(parsed.customEventColors)
+      ? Object.keys(parsed.customEventColors).length
+      : 0;
+
+    return hiddenCount === 0 && recentCount === 0 && customColorCount === 0;
+  }
+
+  scorePersistedPreferencesMatch(parsed) {
+    const currentEntities = Array.isArray(this._config?.entities)
+      ? this._config.entities.filter((entityId) => typeof entityId === 'string' && entityId.startsWith('calendar.'))
+      : [];
+    const candidateEntities = this.extractPersistedPreferenceEntityIds(parsed);
+
+    if (currentEntities.length === 0 || candidateEntities.length === 0) {
+      return Number.NEGATIVE_INFINITY;
+    }
+
+    const currentEntitySet = new Set(currentEntities);
+    const sharedCount = candidateEntities.filter((entityId) => currentEntitySet.has(entityId)).length;
+    if (sharedCount === 0) {
+      return Number.NEGATIVE_INFINITY;
+    }
+
+    let score = sharedCount * 100;
+    score -= Math.abs(candidateEntities.length - currentEntities.length) * 10;
+
+    const currentTitle = typeof this._config?.title === 'string' ? this._config.title.trim() : '';
+    const storedTitle = typeof parsed?.meta?.title === 'string' ? parsed.meta.title.trim() : '';
+    if (currentTitle && storedTitle && currentTitle === storedTitle) {
+      score += 25;
+    }
+
+    if (parsed?.meta?.cardType === 'skylight-calendar-card') {
+      score += 10;
+    }
+
+    return score;
+  }
+
+  findBestPersistedPreferencesMatch({ excludeStorageKeys = [] } = {}) {
+    const prefix = this.getPreferenceStoragePrefix();
+    const excluded = new Set(excludeStorageKeys.filter(Boolean));
+    const storage = window.localStorage;
+    if (!storage) return null;
+
+    let bestMatch = null;
+
+    for (let index = 0; index < storage.length; index += 1) {
+      const storageKey = storage.key(index);
+      if (!storageKey || excluded.has(storageKey) || !storageKey.startsWith(prefix)) {
+        continue;
+      }
+
+      const parsed = this.readPersistedPreferencesPayload(storageKey);
+      if (!parsed) {
+        continue;
+      }
+
+      const score = this.scorePersistedPreferencesMatch(parsed);
+      if (!Number.isFinite(score)) {
+        continue;
+      }
+
+      if (!bestMatch || score > bestMatch.score) {
+        bestMatch = { storageKey, parsed, score };
+      }
+    }
+
+    return bestMatch;
   }
 
   normalizeDashboardPath(pathValue) {
@@ -702,17 +864,58 @@ class SkylightCalendarCard extends HTMLElement {
 
   loadPersistedPreferences() {
     const storageKey = this.getPreferenceStorageKey();
-    if (!storageKey) return;
+    const hasExplicitStorageKey = typeof this._config?.preference_storage_key === 'string' && this._config.preference_storage_key.trim();
+    if (!storageKey && hasExplicitStorageKey) return;
 
     try {
-      const raw = window.localStorage?.getItem(storageKey);
-      if (!raw) return;
+      let resolvedStorageKey = storageKey;
+      let parsed = resolvedStorageKey ? this.readPersistedPreferencesPayload(resolvedStorageKey) : null;
 
-      const parsed = JSON.parse(raw);
+      if (!hasExplicitStorageKey) {
+        const shouldAttemptRecovery = !parsed || this.isPersistedPreferencesEffectivelyEmpty(parsed);
+        if (shouldAttemptRecovery) {
+          const bestMatch = this.findBestPersistedPreferencesMatch({
+            excludeStorageKeys: resolvedStorageKey ? [resolvedStorageKey] : []
+          });
+
+          if (bestMatch && (!parsed || bestMatch.score > this.scorePersistedPreferencesMatch(parsed))) {
+            resolvedStorageKey = bestMatch.storageKey;
+            parsed = bestMatch.parsed;
+          }
+        }
+      }
+
+      if (!parsed) return;
+
+      if (!hasExplicitStorageKey && resolvedStorageKey) {
+        this._resolvedPreferenceStorageKey = resolvedStorageKey;
+      }
 
       if (Array.isArray(parsed.hiddenCalendars)) {
         const knownEntities = new Set(this._config.entities || []);
         this._hiddenCalendars = new Set(parsed.hiddenCalendars.filter((entityId) => knownEntities.has(entityId)));
+      }
+
+      if (parsed.customEventColors && typeof parsed.customEventColors === 'object' && !Array.isArray(parsed.customEventColors)) {
+        this._customEventColors = Object.entries(parsed.customEventColors).reduce((acc, [key, color]) => {
+          const normalizedKey = String(key || '').trim();
+          const normalizedColor = this.normalizeSingleColor(color);
+          if (normalizedKey && normalizedColor) {
+            acc[normalizedKey] = normalizedColor;
+          }
+          return acc;
+        }, {});
+      } else {
+        this._customEventColors = {};
+      }
+
+      if (Array.isArray(parsed.recentCustomColors)) {
+        this._recentCustomColors = parsed.recentCustomColors
+          .map((color) => this.colorToHex(color) || this.normalizeHexColorInput(color))
+          .filter((color) => typeof color === 'string' && !!color)
+          .slice(0, 12);
+      } else {
+        this._recentCustomColors = [];
       }
     } catch (error) {
       console.warn('Failed to load persisted calendar preferences:', error);
@@ -725,7 +928,16 @@ class SkylightCalendarCard extends HTMLElement {
 
     try {
       const payload = {
-        hiddenCalendars: Array.from(this._hiddenCalendars)
+        hiddenCalendars: Array.from(this._hiddenCalendars),
+        customEventColors: this._customEventColors,
+        recentCustomColors: this._recentCustomColors,
+        meta: {
+          cardType: 'skylight-calendar-card',
+          version: 2,
+          title: this._config?.title || null,
+          entities: Array.isArray(this._config?.entities) ? [...this._config.entities] : [],
+          dashboardScope: this.getDashboardScopeKey()
+        }
       };
       window.localStorage?.setItem(storageKey, JSON.stringify(payload));
     } catch (error) {
@@ -803,6 +1015,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   setConfig(config) {
     const previousHeaderWeatherSensor = this._config?.header_weather_sensor || null;
+    const previousResolvedPreferenceStorageKey = this._resolvedPreferenceStorageKey;
     if (!config.entities || !Array.isArray(config.entities)) {
       throw new Error('You need to define calendar entities');
     }
@@ -931,6 +1144,9 @@ class SkylightCalendarCard extends HTMLElement {
       event_styles: normalizedEventStyles,
       day_styles: normalizedDayStyles
     };
+    this._resolvedPreferenceStorageKey = this._config.preference_storage_key
+      ? null
+      : previousResolvedPreferenceStorageKey;
     this._viewMode = this._config.default_view;
     this.applyThemeMode(this._config.color_scheme);
     this._hiddenCalendars = new Set(
@@ -1598,6 +1814,176 @@ class SkylightCalendarCard extends HTMLElement {
 
   getEventIdentityKey(entityId, event) {
     return `${entityId}|${event.uid || ''}|${event.recurring_event_id || ''}|${event.start?.dateTime || event.start?.date || event.start || ''}|${event.end?.dateTime || event.end?.date || event.end || ''}|${event.summary || ''}`;
+  }
+
+  isRecurringEventInstance(event) {
+    return !!(event?.rrule || event?.recurring_event_id || event?.recurrence_id);
+  }
+
+  getCustomColorSeriesKey(event) {
+    if (!event?.entityId || !this.isRecurringEventInstance(event)) {
+      return null;
+    }
+
+    const seriesToken = event.recurring_event_id || event.uid;
+    if (!seriesToken) {
+      return null;
+    }
+
+    return `series|${event.entityId}|${seriesToken}`;
+  }
+
+  getCustomColorEventKey(event) {
+    if (!event?.entityId) {
+      return null;
+    }
+
+    if (event.uid) {
+      return `event|${event.entityId}|uid:${event.uid}`;
+    }
+
+    return `event|${this.getEventIdentityKey(event.entityId, event)}`;
+  }
+
+  getStoredCustomColor(event) {
+    if (!event) return null;
+
+    const seriesKey = this.getCustomColorSeriesKey(event);
+    if (seriesKey && this._customEventColors[seriesKey]) {
+      return this._customEventColors[seriesKey];
+    }
+
+    const eventKey = this.getCustomColorEventKey(event);
+    if (eventKey && this._customEventColors[eventKey]) {
+      return this._customEventColors[eventKey];
+    }
+
+    return null;
+  }
+
+  hasStoredCustomColor(event) {
+    if (event?.isCombinedCalendarEvent && Array.isArray(event.sourceEvents)) {
+      return event.sourceEvents.some((sourceEvent) => !this._hiddenCalendars.has(sourceEvent.entityId) && !!this.getStoredCustomColor(sourceEvent));
+    }
+
+    return !!this.getStoredCustomColor(event);
+  }
+
+  setStoredCustomColor(event, color) {
+    const storageKey = this.getCustomColorSeriesKey(event) || this.getCustomColorEventKey(event);
+    const normalizedColor = this.colorToHex(color) || this.normalizeSingleColor(color);
+    if (!storageKey || !normalizedColor) {
+      return false;
+    }
+
+    this.addRecentCustomColor(normalizedColor);
+    this._customEventColors = {
+      ...this._customEventColors,
+      [storageKey]: normalizedColor
+    };
+    this.persistPreferences();
+    return true;
+  }
+
+  clearStoredCustomColor(event) {
+    const candidateKeys = [
+      this.getCustomColorSeriesKey(event),
+      this.getCustomColorEventKey(event)
+    ].filter(Boolean);
+
+    if (candidateKeys.length === 0) {
+      return false;
+    }
+
+    const nextCustomEventColors = { ...this._customEventColors };
+    let changed = false;
+
+    candidateKeys.forEach((key) => {
+      if (Object.prototype.hasOwnProperty.call(nextCustomEventColors, key)) {
+        delete nextCustomEventColors[key];
+        changed = true;
+      }
+    });
+
+    if (!changed) {
+      return false;
+    }
+
+    this._customEventColors = nextCustomEventColors;
+    this.persistPreferences();
+    return true;
+  }
+
+  getCustomEventColorPresets() {
+    return [
+      '#FF6B6B',
+      '#EF4444',
+      '#DC2626',
+      '#B91C1C',
+      '#F97316',
+      '#EA580C',
+      '#FB923C',
+      '#F59E0B',
+      '#4ECDC4',
+      '#14B8A6',
+      '#0D9488',
+      '#10B981',
+      '#22C55E',
+      '#84CC16',
+      '#A3E635',
+      '#45B7D1',
+      '#06B6D4',
+      '#0EA5E9',
+      '#3B82F6',
+      '#2563EB',
+      '#1D4ED8',
+      '#FFA07A',
+      '#98D8C8',
+      '#F7DC6F',
+      '#BB8FCE',
+      '#85C1E2',
+      '#6366F1',
+      '#4F46E5',
+      '#7C3AED',
+      '#8B5CF6',
+      '#A855F7',
+      '#EC4899'
+    ];
+  }
+
+  normalizeHexColorInput(value) {
+    const raw = String(value || '').trim();
+    if (!raw) return null;
+    const withHash = raw.startsWith('#') ? raw : `#${raw}`;
+    return /^#[0-9a-fA-F]{6}$/.test(withHash) ? withHash.toUpperCase() : null;
+  }
+
+  getRecentCustomColors() {
+    return Array.isArray(this._recentCustomColors) ? this._recentCustomColors : [];
+  }
+
+  addRecentCustomColor(color) {
+    const normalizedColor = this.colorToHex(color) || this.normalizeHexColorInput(color);
+    if (!normalizedColor) {
+      return;
+    }
+
+    this._recentCustomColors = [
+      normalizedColor,
+      ...this.getRecentCustomColors().filter((entry) => entry !== normalizedColor)
+    ].slice(0, 12);
+  }
+
+  getResolvedSingleEventBackgroundColor(event, candidates = null) {
+    if (!event) return null;
+
+    const customColor = this.getStoredCustomColor(event);
+    if (customColor) {
+      return customColor;
+    }
+
+    const resolvedCandidates = candidates || this.getSingleEventStyleCandidates(event);
+    return resolvedCandidates.background_color?.value || event.color;
   }
 
   async fetchEventsInRange(startDate, endDate) {
@@ -4080,6 +4466,143 @@ class SkylightCalendarCard extends HTMLElement {
         gap: 12px;
       }
 
+      .custom-color-button-swatch {
+        display: inline-block;
+        width: 14px;
+        height: 14px;
+        border-radius: 999px;
+        background: var(--custom-color-swatch, #3b82f6);
+        border: 1px solid rgba(17, 24, 39, 0.15);
+        flex: 0 0 auto;
+      }
+
+      .btn-custom-color {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        background: var(--custom-color-button-bg, #f3f4f6);
+        color: var(--custom-color-button-fg, #374151);
+        border: 1px solid rgba(17, 24, 39, 0.08);
+      }
+
+      .btn-custom-color:hover {
+        filter: brightness(0.97);
+        transform: translateY(-1px);
+      }
+
+      .custom-color-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, 40px);
+        gap: 12px;
+        margin-top: 6px;
+        justify-content: start;
+      }
+
+      .custom-color-section {
+        margin-top: 18px;
+      }
+
+      .custom-color-section:first-child {
+        margin-top: 0;
+      }
+
+      .custom-color-section-title {
+        font-size: 13px;
+        font-weight: 600;
+        color: #6b7280;
+        margin-bottom: 10px;
+      }
+
+      .custom-color-option {
+        width: 100%;
+        aspect-ratio: 1;
+        border-radius: 12px;
+        border: 2px solid transparent;
+        background: var(--custom-color-option);
+        cursor: pointer;
+        transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
+      }
+
+      .custom-color-option:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 8px 18px rgba(15, 23, 42, 0.18);
+      }
+
+      .custom-color-option.selected {
+        border-color: #111827;
+        box-shadow: 0 0 0 3px rgba(17, 24, 39, 0.12);
+      }
+
+      .custom-color-current-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin-top: 18px;
+        padding: 12px 14px;
+        border-radius: 10px;
+        background: #f9fafb;
+      }
+
+      .custom-color-current-label {
+        font-size: 13px;
+        font-weight: 600;
+        color: #6b7280;
+      }
+
+      .custom-color-preview {
+        width: 20px;
+        height: 20px;
+        border-radius: 999px;
+        background: var(--custom-color-preview, #3b82f6);
+        border: 1px solid rgba(17, 24, 39, 0.15);
+        flex: 0 0 auto;
+      }
+
+      .custom-color-current-value {
+        font-size: 13px;
+        color: #374151;
+        word-break: break-word;
+      }
+
+      .custom-color-input-row {
+        display: grid;
+        grid-template-columns: 56px minmax(0, 1fr) auto;
+        gap: 12px;
+        align-items: center;
+      }
+
+      .custom-color-picker-input {
+        width: 56px;
+        height: 44px;
+        border: none;
+        padding: 0;
+        background: transparent;
+        cursor: pointer;
+      }
+
+      .custom-color-picker-input::-webkit-color-swatch-wrapper {
+        padding: 0;
+      }
+
+      .custom-color-picker-input::-webkit-color-swatch {
+        border: 1px solid rgba(17, 24, 39, 0.12);
+        border-radius: 10px;
+      }
+
+      .custom-color-picker-input::-moz-color-swatch {
+        border: 1px solid rgba(17, 24, 39, 0.12);
+        border-radius: 10px;
+      }
+
+      .custom-color-hex-input {
+        text-transform: uppercase;
+      }
+
+      .custom-color-error {
+        margin-top: 10px;
+      }
+
       .confirm-dialog {
         background: white;
         border-radius: 12px;
@@ -4389,6 +4912,25 @@ class SkylightCalendarCard extends HTMLElement {
         color: #e2e8f0;
         border-color: #606b7b;
         box-shadow: none;
+      }
+
+      .calendar-container.dark-mode .custom-color-current-row {
+        background: #30363f;
+      }
+
+      .calendar-container.dark-mode .custom-color-current-label,
+      .calendar-container.dark-mode .custom-color-current-value,
+      .calendar-container.dark-mode .custom-color-section-title {
+        color: #d6dee8;
+      }
+
+      .calendar-container.dark-mode .custom-color-option.selected {
+        border-color: #f8fafc;
+        box-shadow: 0 0 0 3px rgba(248, 250, 252, 0.14);
+      }
+
+      .calendar-container.dark-mode .btn-custom-color {
+        border-color: rgba(248, 250, 252, 0.14);
       }
 
       .calendar-container.dark-mode .modal-header,
@@ -5536,11 +6078,16 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getVisibleCalendarBadgesForEvent(event) {
-    if (event.isCombinedCalendarEvent && Array.isArray(event.sourceCalendars)) {
-      return event.sourceCalendars.filter(calendar => !this._hiddenCalendars.has(calendar.entityId));
+    if (event.isCombinedCalendarEvent && Array.isArray(event.sourceEvents)) {
+      return event.sourceEvents
+        .filter((sourceEvent) => !this._hiddenCalendars.has(sourceEvent.entityId))
+        .map((sourceEvent) => ({
+          entityId: sourceEvent.entityId,
+          color: this.getResolvedSingleEventBackgroundColor(sourceEvent)
+        }));
     }
 
-    return [{ entityId: event.entityId, color: event.color }];
+    return [{ entityId: event.entityId, color: this.getResolvedSingleEventBackgroundColor(event) || event.color }];
   }
 
   renderEventIcon(event) {
@@ -5761,6 +6308,10 @@ class SkylightCalendarCard extends HTMLElement {
 
   getEventBubbleFontColor(event) {
     if (!event) return 'white';
+    if (this.hasStoredCustomColor(event)) {
+      return this.getContractColor(this.getEventBackgroundColor(event));
+    }
+
     const styleOverrides = this.getEventStyleOverrides(event);
     if (styleOverrides?.event_font_color) {
       return styleOverrides.event_font_color;
@@ -6335,7 +6886,7 @@ class SkylightCalendarCard extends HTMLElement {
       }));
 
       const backgroundColors = sourceCandidates.map(({ sourceEvent, candidates }) =>
-        candidates.background_color?.value || sourceEvent.color
+        this.getResolvedSingleEventBackgroundColor(sourceEvent, candidates)
       );
       const uniqueBackgroundCount = new Set(backgroundColors).size;
       const hasDuplicateBackgroundColors = uniqueBackgroundCount !== backgroundColors.length;
@@ -6366,7 +6917,7 @@ class SkylightCalendarCard extends HTMLElement {
       acc[key] = meta.value;
       return acc;
     }, {});
-    overrides.backgroundColors = [overrides.background_color || event.color];
+    overrides.backgroundColors = [this.getResolvedSingleEventBackgroundColor(event, candidates)];
     overrides.hasDuplicateBackgroundColors = false;
     return overrides;
   }
@@ -8453,6 +9004,261 @@ class SkylightCalendarCard extends HTMLElement {
     });
   }
 
+  showCombinedCustomColorSelectionModal(event, onCloseBack = null) {
+    const modal = this.getRootElementById('event-modal');
+    const content = this.getRootElementById('modal-content');
+    const sourceEvents = (event.sourceEvents || []).filter((sourceEvent) => !this._hiddenCalendars.has(sourceEvent.entityId));
+
+    if (sourceEvents.length === 0) {
+      this.showEventModal(event, onCloseBack);
+      return;
+    }
+
+    const returnToEventModal = () => this.showEventModal(event, onCloseBack);
+
+    content.innerHTML = `
+      <div class="confirm-dialog">
+        <h3 class="confirm-title">${this.t('customColor')}</h3>
+        <p class="confirm-message">Select which calendar copy to color.</p>
+
+        <div class="recurring-options">
+          ${sourceEvents.map((sourceEvent, index) => `
+            <label class="recurring-option">
+              <input type="radio" name="combined-custom-color-option" class="combined-custom-color-option" data-index="${index}" ${index === 0 ? 'checked' : ''} />
+              <div class="recurring-option-label">
+                <div class="recurring-option-title">${this.escapeHtml(this.getCalendarName(sourceEvent.entityId))}</div>
+                <div class="recurring-option-description">${this.escapeHtml(sourceEvent.summary || this.t('untitledEvent'))}</div>
+              </div>
+              <span class="custom-color-button-swatch" style="--custom-color-swatch: ${this.getResolvedSingleEventBackgroundColor(sourceEvent)};"></span>
+            </label>
+          `).join('')}
+        </div>
+
+        <div class="confirm-actions">
+          <button class="btn btn-secondary" id="cancel-combined-custom-color-btn">${this.t('cancel')}</button>
+          <button class="btn btn-primary" id="confirm-combined-custom-color-btn">${this.t('customColor')}</button>
+        </div>
+      </div>
+    `;
+
+    modal.classList.add('show');
+    this.setModalBackHandler(returnToEventModal);
+
+    this.getRootElementById('cancel-combined-custom-color-btn')?.addEventListener('click', () => {
+      this._activeModalBackHandler = null;
+      modal.classList.remove('show');
+      returnToEventModal();
+    });
+
+    this.getRootElementById('confirm-combined-custom-color-btn')?.addEventListener('click', () => {
+      const selectedIndex = Number.parseInt(
+        this._root.querySelector('input[name="combined-custom-color-option"]:checked')?.getAttribute('data-index'),
+        10
+      );
+
+      if (!Number.isInteger(selectedIndex) || selectedIndex < 0 || selectedIndex >= sourceEvents.length) {
+        return;
+      }
+
+      const selectedEvent = sourceEvents[selectedIndex];
+      this._activeModalBackHandler = null;
+      modal.classList.remove('show');
+      this.showCustomColorModal(selectedEvent, {
+        onCloseBack: () => this.showCombinedCustomColorSelectionModal(event, onCloseBack),
+        onApplied: returnToEventModal
+      });
+    });
+  }
+
+  showCustomColorModal(event, { onCloseBack = null, onApplied = null } = {}) {
+    const modal = this.getRootElementById('event-modal');
+    const content = this.getRootElementById('modal-content');
+    const currentCustomColor = this.getStoredCustomColor(event);
+    const previewColor = currentCustomColor || this.getEventBackgroundColor(event) || event?.color || '#3b82f6';
+    const normalizedCurrentCustomColor = this.colorToHex(currentCustomColor) || this.normalizeHexColorInput(currentCustomColor);
+    const initialPickerColor = (this.colorToHex(previewColor) || '#3B82F6').toLowerCase();
+    const colorHint = this.isRecurringEventInstance(event) ? this.t('customColorSeriesHint') : this.t('customColorEventHint');
+    const presetButtons = this.getCustomEventColorPresets()
+      .map((color) => `
+        <button
+          type="button"
+          class="custom-color-option ${normalizedCurrentCustomColor === color ? 'selected' : ''}"
+          data-custom-event-color="${color}"
+          style="--custom-color-option: ${color};"
+          aria-label="${this.t('customColor')} ${color}"
+          title="${color}">
+        </button>
+      `)
+      .join('');
+    const recentButtons = this.getRecentCustomColors()
+      .map((color) => `
+        <button
+          type="button"
+          class="custom-color-option ${normalizedCurrentCustomColor === color ? 'selected' : ''}"
+          data-custom-event-color="${color}"
+          style="--custom-color-option: ${color};"
+          aria-label="${this.t('recentColors')} ${color}"
+          title="${color}">
+        </button>
+      `)
+      .join('');
+
+    content.innerHTML = `
+      <div class="modal-header">
+        <div>
+          <h3 class="modal-title">${this.t('customColorTitle')}</h3>
+          <div class="confirm-message">${this.escapeHtml(colorHint)}</div>
+        </div>
+        <button class="modal-close" id="close-modal">×</button>
+      </div>
+      <div class="modal-body">
+        ${recentButtons ? `
+          <div class="custom-color-section">
+            <div class="custom-color-section-title">${this.t('recentColors')}</div>
+            <div class="custom-color-grid">
+              ${recentButtons}
+            </div>
+          </div>
+        ` : ''}
+
+        <div class="custom-color-section">
+          <div class="custom-color-section-title">${this.t('customColor')}</div>
+          <div class="custom-color-grid">
+            ${presetButtons}
+          </div>
+        </div>
+
+        <div class="custom-color-section">
+          <div class="custom-color-section-title">${this.t('customColorInput')}</div>
+          <div class="custom-color-input-row">
+            <input type="color" class="custom-color-picker-input" id="custom-color-native-input" value="${initialPickerColor}" aria-label="${this.t('customColorInput')}">
+            <input type="text" class="form-input custom-color-hex-input" id="custom-color-hex-input" value="${initialPickerColor.toUpperCase()}" placeholder="#3F51B5" spellcheck="false" autocapitalize="characters" />
+            <button class="btn btn-primary" id="apply-custom-color-btn">${this.t('applyCustomColor')}</button>
+          </div>
+          <div id="custom-color-form-error" class="error-message custom-color-error" style="display:none;"></div>
+        </div>
+
+        <div class="custom-color-current-row">
+          <span class="custom-color-current-label">${this.t('customColor')}</span>
+          <span class="custom-color-preview" id="custom-color-preview" style="--custom-color-preview: ${previewColor};"></span>
+          <span class="custom-color-current-value" id="custom-color-current-value">${this.escapeHtml(currentCustomColor || this.t('usingDefaultColor'))}</span>
+        </div>
+
+        <div class="modal-actions">
+          <div class="modal-actions-left">
+            ${currentCustomColor ? `<button class="btn btn-secondary" id="clear-custom-color-btn">${this.t('clearCustomColor')}</button>` : ''}
+          </div>
+          <div class="modal-actions-right">
+            <button class="btn btn-secondary" id="cancel-custom-color-btn">${this.t('cancel')}</button>
+          </div>
+        </div>
+      </div>
+    `;
+
+    modal.classList.add('show');
+    this.setModalBackHandler(onCloseBack);
+
+    const closeCustomColorModal = () => {
+      if (this._activeModalBackHandler) {
+        const backHandler = this._activeModalBackHandler;
+        this._activeModalBackHandler = null;
+        backHandler();
+      } else {
+        modal.classList.remove('show');
+      }
+    };
+
+    const customColorPreview = this.getRootElementById('custom-color-preview');
+    const customColorValue = this.getRootElementById('custom-color-current-value');
+    const customColorNativeInput = this.getRootElementById('custom-color-native-input');
+    const customColorHexInput = this.getRootElementById('custom-color-hex-input');
+    const customColorFormError = this.getRootElementById('custom-color-form-error');
+
+    const hideCustomColorError = () => {
+      if (customColorFormError) {
+        customColorFormError.style.display = 'none';
+        customColorFormError.textContent = '';
+      }
+    };
+
+    const showCustomColorError = (message) => {
+      if (customColorFormError) {
+        customColorFormError.textContent = message;
+        customColorFormError.style.display = 'block';
+      }
+    };
+
+    const syncCustomColorDraft = (color) => {
+      const normalizedHex = this.normalizeHexColorInput(color);
+      if (!normalizedHex) {
+        return false;
+      }
+
+      if (customColorNativeInput) customColorNativeInput.value = normalizedHex.toLowerCase();
+      if (customColorHexInput) customColorHexInput.value = normalizedHex;
+      if (customColorPreview) customColorPreview.style.setProperty('--custom-color-preview', normalizedHex);
+      if (customColorValue) customColorValue.textContent = normalizedHex;
+      hideCustomColorError();
+      return true;
+    };
+
+    const applyCustomColorSelection = (color) => {
+      if (!this.setStoredCustomColor(event, color)) {
+        showCustomColorError(this.t('invalidHexColor'));
+        return;
+      }
+      completeCustomColorChange();
+    };
+
+    const completeCustomColorChange = () => {
+      this._activeModalBackHandler = null;
+      modal.classList.remove('show');
+      this.render();
+      if (typeof onApplied === 'function') {
+        onApplied();
+      } else {
+        this.showEventModal(event);
+      }
+    };
+
+    this.getRootElementById('close-modal')?.addEventListener('click', closeCustomColorModal);
+    this.getRootElementById('cancel-custom-color-btn')?.addEventListener('click', closeCustomColorModal);
+
+    this._root.querySelectorAll('[data-custom-event-color]').forEach((button) => {
+      button.addEventListener('click', () => {
+        applyCustomColorSelection(button.getAttribute('data-custom-event-color'));
+      });
+    });
+
+    customColorNativeInput?.addEventListener('input', (inputEvent) => {
+      syncCustomColorDraft(inputEvent.target.value);
+    });
+
+    customColorHexInput?.addEventListener('input', (inputEvent) => {
+      const normalizedHex = this.normalizeHexColorInput(inputEvent.target.value);
+      if (normalizedHex) {
+        syncCustomColorDraft(normalizedHex);
+      }
+    });
+
+    this.getRootElementById('apply-custom-color-btn')?.addEventListener('click', () => {
+      const normalizedHex = this.normalizeHexColorInput(customColorHexInput?.value);
+      if (!normalizedHex) {
+        showCustomColorError(this.t('invalidHexColor'));
+        return;
+      }
+      applyCustomColorSelection(normalizedHex);
+    });
+
+    this.getRootElementById('clear-custom-color-btn')?.addEventListener('click', () => {
+      if (!this.clearStoredCustomColor(event)) {
+        closeCustomColorModal();
+        return;
+      }
+      completeCustomColorChange();
+    });
+  }
+
 
   showDeleteConfirmation(event, selectedEvents = null) {
     const modal = this.getRootElementById('event-modal');
@@ -8551,6 +9357,7 @@ class SkylightCalendarCard extends HTMLElement {
 
             if (!targetIsRecurring) {
               await this.deleteEvent(targetEvent.entityId, targetEvent.uid);
+              this.clearStoredCustomColor(targetEvent);
               continue;
             }
 
@@ -8563,6 +9370,7 @@ class SkylightCalendarCard extends HTMLElement {
             } else if (selectedOption === 'all') {
               // Delete entire series
               await this.deleteEvent(targetEvent.entityId, targetEvent.uid);
+              this.clearStoredCustomColor(targetEvent);
             } else {
               // Fallback for recurring targets without recurrence_id
               await this.deleteEvent(targetEvent.entityId, targetEvent.uid);
@@ -8572,6 +9380,7 @@ class SkylightCalendarCard extends HTMLElement {
           for (const targetEvent of deleteTargets) {
             // Delete single event
             await this.deleteEvent(targetEvent.entityId, targetEvent.uid);
+            this.clearStoredCustomColor(targetEvent);
           }
         }
 
@@ -8642,7 +9451,7 @@ class SkylightCalendarCard extends HTMLElement {
     const visibleBadges = this.getVisibleCalendarBadgesForEvent(event);
     const combinedBadgeHtml = event.isCombinedCalendarEvent
       ? `<div style="display:flex; gap:6px; flex-wrap:wrap; margin-top:8px;">${visibleBadges.map(calendar => `<span class="modal-calendar-badge" style="background: ${calendar.color}; color: white; display: inline-block; padding: 4px 10px; border-radius: 12px; font-size: 12px;">${this.escapeHtml(this.getCalendarName(calendar.entityId))}</span>`).join('')}</div>`
-      : `<div class="modal-calendar-badge" style="background: ${event.color}; color: white; display: inline-block; padding: 4px 12px; border-radius: 12px; font-size: 12px; margin-top: 8px;">${this.escapeHtml(calendarName)}</div>`;
+      : `<div class="modal-calendar-badge" style="background: ${this.getEventBackgroundColor(event)}; color: ${this.getContractColor(this.getEventBackgroundColor(event))}; display: inline-block; padding: 4px 12px; border-radius: 12px; font-size: 12px; margin-top: 8px;">${this.escapeHtml(calendarName)}</div>`;
 
     // For edit/delete to work, we need:
     // 1. Event management enabled
@@ -8656,6 +9465,10 @@ class SkylightCalendarCard extends HTMLElement {
     // WebSocket delete works for Google Calendar and other integrations
     const canEdit = canModify;
     const canDelete = canModify; // WebSocket delete works for all calendars including Google
+    const canCustomColor = true;
+    const customColor = this.getStoredCustomColor(event);
+    const customColorButtonColor = customColor || this.getEventBackgroundColor(event);
+    const customColorButtonTextColor = this.getContractColor(customColorButtonColor);
 
     content.innerHTML = `
       <div class="modal-header">
@@ -8723,12 +9536,13 @@ class SkylightCalendarCard extends HTMLElement {
           </div>
         ` : ''}
 
-        ${(canEdit || canDelete) ? `
+        ${(canEdit || canDelete || canCustomColor) ? `
           <div class="modal-actions">
             <div class="modal-actions-left">
               ${canDelete ? `<button class="btn btn-danger" id="delete-event-btn">${this.t('delete')}</button>` : ''}
             </div>
             <div class="modal-actions-right">
+              ${canCustomColor ? `<button class="btn btn-custom-color" id="custom-color-btn" style="--custom-color-button-bg: ${customColorButtonColor}; --custom-color-button-fg: ${customColorButtonTextColor};">${this.t('customColor')}</button>` : ''}
               ${canEdit ? `<button class="btn btn-primary" id="edit-event-btn">${this.t('editEvent')}</button>` : ''}
             </div>
           </div>
@@ -8759,6 +9573,22 @@ class SkylightCalendarCard extends HTMLElement {
         return;
       }
       this.showEditConfirmation(event, startDate, endDate, isAllDay);
+    });
+
+    this.getRootElementById('custom-color-btn')?.addEventListener('click', () => {
+      this._activeModalBackHandler = null;
+      modal.classList.remove('show');
+      const reopenEventModal = () => this.showEventModal(event, onCloseBack);
+
+      if (event.isCombinedCalendarEvent && Array.isArray(event.sourceEvents) && event.sourceEvents.length > 1) {
+        this.showCombinedCustomColorSelectionModal(event, onCloseBack);
+        return;
+      }
+
+      this.showCustomColorModal(event, {
+        onCloseBack: reopenEventModal,
+        onApplied: reopenEventModal
+      });
     });
 
     // Delete button


### PR DESCRIPTION
This adds local-only custom event colors to skylight-calendar-card without modifying the underlying Home Assistant calendar events.

Users can now open an event, choose Custom Color, and apply a color override that is stored locally in the card’s preference storage. Recurring events share the same custom color across the series, and combined events prompt for which source calendar copy to color.

This PR also improves persistence so custom colors survive card reconfiguration when calendars are added or removed.

**Behavior details**
- Custom colors are local to the card and do not modify source calendar entities
- Recurring events use a shared series-level color key when possible
- Clearing a custom color removes only the local override
- Delete flows clean up matching local overrides for deleted events/series
- Recent colors are stored locally and reused in the color modal

**What changed**

- Added a Custom Color action in the event modal
- Added local custom event color storage
- Applied custom colors across all event render paths
- Added recurring-series color support
- Added combined-event source selection before applying custom color
- Added preset colors, recent colors, and custom hex/native color input
- Made the Custom Color button reflect the current effective color
- Fixed the custom color button swatch rendering artifact
- Fixed recent color swatch sizing so it matches preset swatches
- Improved preference storage resolution so custom colors persist across card config changes
- Added stored metadata to preference payloads for more reliable recovery of prior local settings