### PR TITLE
Preserve agenda scroll position across renders and add render control for event loads

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -637,6 +637,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._agendaVisibleEndDate = null;
     this._agendaDaysPerScrollLoad = 7;
     this._agendaScrollLoadLock = false;
+    this._agendaPendingScrollTop = null;
     this._swipeStartX = null;
     this._swipeStartY = null;
     this._swipeTracking = false;
@@ -1114,7 +1115,7 @@ class SkylightCalendarCard extends HTMLElement {
     this.refreshWeatherForecastData();
 
     if (shouldRender) {
-      this.render();
+      this.renderPreservingAgendaScroll();
     }
 
     // Refresh only when stale or when current view needs dates outside loaded range.
@@ -1833,7 +1834,7 @@ class SkylightCalendarCard extends HTMLElement {
       .join('|');
   }
 
-  async updateEvents() {
+  async updateEvents({ preserveScroll = false } = {}) {
     if (!this._hass || this._fetching) return;
 
     const { startDate, endDate } = this.getEventFetchRange();
@@ -1862,7 +1863,11 @@ class SkylightCalendarCard extends HTMLElement {
 
         if (shouldRenderForUnchangedData) {
           this._lastUnchangedDataRender = now;
-          this.render();
+          if (preserveScroll) {
+            this.renderPreservingAgendaScroll();
+          } else {
+            this.render();
+          }
         }
 
         return;
@@ -1879,13 +1884,17 @@ class SkylightCalendarCard extends HTMLElement {
       this._events = this.limitEvents(mergedEvents);
       this._loadedEventRange = { startDate, endDate };
       this._lastUnchangedDataRender = Date.now();
-      this.render();
+      if (preserveScroll) {
+        this.renderPreservingAgendaScroll();
+      } else {
+        this.render();
+      }
     } finally {
       this._fetching = false;
     }
   }
 
-  async extendEventsForRange(startDate, endDate) {
+  async extendEventsForRange(startDate, endDate, { render = true } = {}) {
     if (!this._hass || this._fetching) return;
 
     this._fetching = true;
@@ -1894,7 +1903,9 @@ class SkylightCalendarCard extends HTMLElement {
     try {
       const additionalEvents = await this.fetchEventsInRange(startDate, endDate);
       this._events = this.mergeEvents(this._events, additionalEvents);
-      this.render();
+      if (render) {
+        this.render();
+      }
     } finally {
       this._fetching = false;
     }
@@ -1918,7 +1929,8 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     if (force || shouldRefreshForAge || !this._loadedEventRange) {
-      await this.updateEvents();
+      const shouldPreserveScrollDuringRefresh = this._viewMode === 'agenda' && !force && !renderIfCovered;
+      await this.updateEvents({ preserveScroll: shouldPreserveScrollDuringRefresh });
       return;
     }
 
@@ -1951,7 +1963,7 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     for (const range of missingRanges) {
-      await this.extendEventsForRange(range.startDate, range.endDate);
+      await this.extendEventsForRange(range.startDate, range.endDate, { render: false });
     }
 
     this._loadedEventRange = {
@@ -2139,6 +2151,18 @@ class SkylightCalendarCard extends HTMLElement {
     if (!resolvedMaxHeight) return '';
 
     return `max-height: ${resolvedMaxHeight}px; overflow-y: auto;`;
+  }
+
+  preserveAgendaScrollForNextRender() {
+    if (this._viewMode !== 'agenda' || Number.isFinite(this._agendaPendingScrollTop)) return;
+    const agendaContainer = this.getRootElementById('agenda-container');
+    if (!agendaContainer) return;
+    this._agendaPendingScrollTop = agendaContainer.scrollTop;
+  }
+
+  renderPreservingAgendaScroll() {
+    this.preserveAgendaScrollForNextRender();
+    this.render();
   }
 
   updateWeekStandardFixedOffsetHeightFromDom() {
@@ -4738,6 +4762,8 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   render() {
+    const shouldRestoreAgendaScrollPosition = this._viewMode === 'agenda' && Number.isFinite(this._agendaPendingScrollTop);
+    const agendaScrollTopToRestore = shouldRestoreAgendaScrollPosition ? this._agendaPendingScrollTop : null;
     const today = new Date();
     const year = this._currentDate.getFullYear();
     const month = this._currentDate.getMonth();
@@ -4840,6 +4866,17 @@ class SkylightCalendarCard extends HTMLElement {
     this.updateWeekStandardFixedOffsetHeightFromDom();
     this.updateMonthContainerTopInViewportFromDom();
     this.updateAgendaContainerTopInViewportFromDom();
+
+    if (shouldRestoreAgendaScrollPosition) {
+      window.requestAnimationFrame(() => {
+        const agendaContainer = this.getRootElementById('agenda-container');
+        if (agendaContainer) {
+          agendaContainer.scrollTop = agendaScrollTopToRestore;
+        }
+      });
+    }
+    this._agendaPendingScrollTop = null;
+
     if (this._viewMode === 'agenda') {
       window.requestAnimationFrame(() => {
         this.updateAgendaVisibleDateRangeFromDom();
@@ -6767,7 +6804,7 @@ class SkylightCalendarCard extends HTMLElement {
           this._hiddenCalendars.add(entityId);
         }
         this.persistPreferences();
-        this.render();
+        this.renderPreservingAgendaScroll();
       });
     });
 
@@ -6813,8 +6850,10 @@ class SkylightCalendarCard extends HTMLElement {
       const previousScrollHeight = agendaContainer.scrollHeight;
 
       if (nearBottom) {
+        this._agendaPendingScrollTop = agendaContainer.scrollTop;
         this._agendaEndDate.setDate(this._agendaEndDate.getDate() + this._agendaDaysPerScrollLoad);
       } else if (nearTop && canLoadPastAgendaDays) {
+        this._agendaPendingScrollTop = null;
         this._agendaStartDate.setDate(this._agendaStartDate.getDate() - this._agendaDaysPerScrollLoad);
       }
 
@@ -6950,7 +6989,7 @@ class SkylightCalendarCard extends HTMLElement {
   flushPendingHeaderTimeRender() {
     if (!this._pendingHeaderSensorRender) return;
     this._pendingHeaderSensorRender = false;
-    this.render();
+    this.renderPreservingAgendaScroll();
   }
 
   navigateToPreviousPeriod() {
@@ -9066,7 +9105,7 @@ class SkylightCalendarCard extends HTMLElement {
           const nextForecast = Array.isArray(message?.forecast) ? message.forecast : [];
           this._weatherForecastByEntity.set(entityId, nextForecast);
           if (!this.isEventManagementDialogOpen()) {
-            this.render();
+            this.renderPreservingAgendaScroll();
           } else {
             this._pendingHeaderSensorRender = true;
           }
@@ -9129,7 +9168,7 @@ class SkylightCalendarCard extends HTMLElement {
         this._weatherForecastByEntity.set(entityId, dailyForecast);
         this._weatherForecastRefreshRetryAtByEntity.delete(entityId);
         if (!this.isEventManagementDialogOpen()) {
-          this.render();
+          this.renderPreservingAgendaScroll();
         } else {
           this._pendingHeaderSensorRender = true;
         }

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -637,6 +637,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._agendaVisibleEndDate = null;
     this._agendaDaysPerScrollLoad = 7;
     this._agendaScrollLoadLock = false;
+    this._agendaSuppressScrollHandling = false;
     this._agendaPendingScrollTop = null;
     this._swipeStartX = null;
     this._swipeStartY = null;
@@ -2163,6 +2164,17 @@ class SkylightCalendarCard extends HTMLElement {
   renderPreservingAgendaScroll() {
     this.preserveAgendaScrollForNextRender();
     this.render();
+  }
+
+  setAgendaScrollTopWithoutTriggeringLoad(container, scrollTop) {
+    if (!container) return;
+
+    this._agendaSuppressScrollHandling = true;
+    container.scrollTop = scrollTop;
+
+    window.requestAnimationFrame(() => {
+      this._agendaSuppressScrollHandling = false;
+    });
   }
 
   updateWeekStandardFixedOffsetHeightFromDom() {
@@ -4870,9 +4882,7 @@ class SkylightCalendarCard extends HTMLElement {
     if (shouldRestoreAgendaScrollPosition) {
       window.requestAnimationFrame(() => {
         const agendaContainer = this.getRootElementById('agenda-container');
-        if (agendaContainer) {
-          agendaContainer.scrollTop = agendaScrollTopToRestore;
-        }
+        this.setAgendaScrollTopWithoutTriggeringLoad(agendaContainer, agendaScrollTopToRestore);
       });
     }
     this._agendaPendingScrollTop = null;
@@ -6837,7 +6847,7 @@ class SkylightCalendarCard extends HTMLElement {
     });
 
     agendaContainer?.addEventListener('scroll', async () => {
-      if (this._viewMode !== 'agenda' || this._agendaScrollLoadLock) return;
+      if (this._viewMode !== 'agenda' || this._agendaScrollLoadLock || this._agendaSuppressScrollHandling) return;
       this.updateAgendaVisibleDateRangeFromDom();
       const threshold = 80;
       const nearBottom = agendaContainer.scrollTop + agendaContainer.clientHeight >= agendaContainer.scrollHeight - threshold;
@@ -6862,7 +6872,10 @@ class SkylightCalendarCard extends HTMLElement {
       if (nearTop && canLoadPastAgendaDays) {
         const updatedContainer = this.getRootElementById('agenda-container');
         if (updatedContainer) {
-          updatedContainer.scrollTop = updatedContainer.scrollHeight - previousScrollHeight + threshold;
+          this.setAgendaScrollTopWithoutTriggeringLoad(
+            updatedContainer,
+            updatedContainer.scrollHeight - previousScrollHeight + threshold
+          );
         }
       }
 


### PR DESCRIPTION
### Motivation
- Prevent the agenda view from jumping when background updates (events, header sensors, weather) or user interactions trigger re-renders. 
- Avoid unnecessary layout shifts when loading additional agenda days or toggling calendar visibility. 
- Provide finer control over when a render should restore the agenda scroll position versus perform a normal render. 

### Description
- Added `_agendaPendingScrollTop` state plus `preserveAgendaScrollForNextRender()` and `renderPreservingAgendaScroll()` helpers to capture and restore agenda scroll position across renders. 
- Updated `render()` to restore the saved agenda scroll position after DOM update and to clear the pending value. 
- Replaced direct `render()` calls with `renderPreservingAgendaScroll()` in places that can occur while the user is viewing the agenda (calendar badge toggles, header sensor updates, weather subscription/refresh, pending header flush). 
- Extended `updateEvents()` with a `preserveScroll` option and `extendEventsForRange()` with a `render` flag, and updated `ensureEventsForCurrentRange()` to decide when to preserve scroll during background refreshes; adjusted agenda scroll handler to set or clear `_agendaPendingScrollTop` when loading more days.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee3a20ebc8331a821518d51a7f53a)